### PR TITLE
refactor(database): 重构数据库连接管理实现

### DIFF
--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/DZT.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/DZT.kt
@@ -1,21 +1,14 @@
 package cn.tj.dzd.mc.dzt
 
-import cn.tj.dzd.mc.dzt.mapping.DatabaseManager
 import taboolib.common.platform.Plugin
 import taboolib.common.platform.function.info
 
 object DZT : Plugin() {
     override fun onEnable() {
         info("DZD 基础插件已启用。")
-        
-        // 检查数据库状态，如果数据库不在线则会自动关闭服务器
-        if (DatabaseManager.checkDatabaseStatus()) {
-            info("数据库连接正常。")
-        }
     }
     
     override fun onDisable() {
         info("DZD 基础插件正在关闭。")
-        DatabaseManager.shutdown()
     }
 }

--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/mapping/DatabaseManager.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/mapping/DatabaseManager.kt
@@ -1,118 +1,69 @@
 package cn.tj.dzd.mc.dzt.mapping
 
 import org.bukkit.Bukkit
-import org.bukkit.Location
+import taboolib.common.LifeCycle
+import taboolib.common.platform.Awake
 import taboolib.common.platform.function.releaseResourceFile
 import taboolib.common.platform.function.severe
+import taboolib.expansion.submitChain
 import taboolib.module.configuration.Configuration
 import taboolib.module.database.getHost
+import taboolib.platform.util.onlinePlayers
 import taboolib.platform.util.runTask
 import java.sql.SQLException
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicBoolean
 
 private val config = Configuration.loadFromFile(releaseResourceFile("Config.yml"))
 val host = config.getHost("database")
 val dataSource = host.createDataSource()
 
+@Awake
 object DatabaseManager {
-    
-    private val isDatabaseOnline = AtomicBoolean(false)
-    private val scheduler = Executors.newScheduledThreadPool(1)
-    
-    init {
-        // 初始化时测试数据库连接
-        testConnection()
-        
-        // 启动定时检查任务
-        scheduler.scheduleAtFixedRate({
-            try {
-                if (!testConnection()) {
-                    severe("§c数据库连接丢失！正在关闭服务器...")
-                    stopServer()
-                }
-            } catch (e: Exception) {
-                severe("§c数据库监控出现异常: ${e.message}")
-                stopServer()
+    @Awake(LifeCycle.ACTIVE)
+    fun onActive() {
+        submitChain {
+            async(period = 600L) {
+                checkDatabaseStatus()
             }
-        }, 5, 30, TimeUnit.SECONDS) // 每30秒检查一次，延迟5秒开始
+        }
     }
 
-    private fun stopServer() {
-        Location(Bukkit.getWorlds()[0], 0.0, 0.0, 0.0).runTask({
-            Bukkit.dispatchCommand(Bukkit.getConsoleSender(), "stop")
-            Bukkit.shutdown()
-        })
-    }
-    
-    /**
-     * 测试数据库连接
-     */
-    private fun testConnection(): Boolean {
-        return try {
-            val connection = dataSource.connection
-            if (connection.isValid(5)) { // 5秒超时验证连接
-                connection.close()
-                isDatabaseOnline.set(true)
-                true
-            } else {
-                isDatabaseOnline.set(false)
-                false
-            }
-        } catch (e: SQLException) {
-            severe("§c数据库连接失败: ${e.message}")
-            isDatabaseOnline.set(false)
-            false
-        } catch (e: Exception) {
-            severe("§c数据库连接异常: ${e.message}")
-            isDatabaseOnline.set(false)
-            false
-        }
-    }
-    
     /**
      * 检查数据库状态
-     * @return 如果数据库在线返回true，否则直接关闭服务器
      */
-    fun checkDatabaseStatus(): Boolean {
-        if (isDatabaseOnline.get()) {
-            return true
-        } else {
-            severe("§c数据库当前不在线！正在关闭服务器以防止数据损坏...")
-            stopServer()
-            return false
+    fun checkDatabaseStatus() {
+        submitChain {
+            async {
+                try {
+                    dataSource.connection.use { connection ->
+                        if (!connection.isValid(5)) {
+                            stopServer()
+                        }
+                    }
+                } catch (e: SQLException) {
+                    severe("数据库连接异常: ${e.message}")
+                    stopServer()
+                } catch (e: NoClassDefFoundError) {
+                    severe("数据库异常: ${e.message}")
+                    stopServer()
+                }
+            }
         }
     }
-    
+
     /**
-     * 获取数据库连接状态
+     * 停止服务器
      */
-    fun isDatabaseOnline(): Boolean {
-        return isDatabaseOnline.get()
-    }
-    
-    /**
-     * 关闭数据库管理器
-     */
-    fun shutdown() {
-        scheduler.shutdown()
-        try {
-            if (!scheduler.awaitTermination(5, TimeUnit.SECONDS)) {
-                scheduler.shutdownNow()
+    private fun stopServer() {
+        severe("数据库异常，正在终止服务器...")
+        submitChain {
+            sync {
+                for (pl in onlinePlayers) {
+                    pl.runTask({
+                        pl.kickPlayer("我们无法连接至数据库，请联系运维排查原因。\nQWQ")
+                    })
+                }
+                Bukkit.shutdown()
             }
-        } catch (e: InterruptedException) {
-            scheduler.shutdownNow()
-            Thread.currentThread().interrupt()
-        }
-        
-        // 尝试关闭数据源 - 使用反射或其他方式根据实际类型关闭
-        try {
-            if (dataSource is AutoCloseable) {
-                dataSource.close()
-            }
-        } catch (e: Exception) {
-            severe("§c关闭数据源时发生错误: ${e.message}")
         }
     }
 }


### PR DESCRIPTION
- 移除手动线程池调度，改用TabooLib的submitChain异步任务
- 使用@Awake注解替代手动初始化数据库检查逻辑
- 简化数据库状态检查逻辑，移除AtomicBoolean状态管理
- 改进服务器关闭流程，先踢出在线玩家再关闭服务器
- 移除DatabaseManager的shutdown方法和相关资源清理代码
- 优化数据库连接验证方式，使用connection.isValid方法进行检查
- 统一异常处理逻辑，增加NoClassDefFoundError异常捕获