### PR TITLE
feat: 完善经济系统与侧边栏功能

### DIFF
--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/DZT.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/DZT.kt
@@ -1,14 +1,17 @@
 package cn.tj.dzd.mc.dzt
 
+import cn.tj.dzd.mc.dzt.sidebar.Sidebar
 import taboolib.common.platform.Plugin
 import taboolib.common.platform.function.info
 
 object DZT : Plugin() {
     override fun onEnable() {
+        Sidebar.start()
         info("DZD 基础插件已启用。")
     }
     
     override fun onDisable() {
+        Sidebar.stop()
         info("DZD 基础插件正在关闭。")
     }
 }

--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/data/DatabaseCache.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/data/DatabaseCache.kt
@@ -1,0 +1,53 @@
+package cn.tj.dzd.mc.dzt.data
+
+import taboolib.expansion.DataMapper
+import taboolib.expansion.MapperConfig
+import taboolib.expansion.mapper
+import kotlin.properties.ReadOnlyProperty
+
+private const val BEAN_CACHE_MAXIMUM_SIZE = 10_000
+private const val QUERY_CACHE_MAXIMUM_SIZE = 1_000
+private const val CACHE_EXPIRE_AFTER_ACCESS_SECONDS = 600L
+
+/**
+ * 创建启用 TabooLib L2 双层缓存的数据库映射器。
+ *
+ * L2 缓存由 Bean Cache 和 Query Cache 组成：
+ * - Bean Cache 缓存按实体 ID 查询的结果，写入同一 ID 时细粒度失效。
+ * - Query Cache 缓存条件查询结果，任意写操作后按表清空，避免旧查询结果残留。
+ *
+ * @param source 数据库配置源。
+ * @param flags 数据库连接标记。
+ * @param clearFlags 是否清空默认连接标记。
+ * @param ssl SSL 配置。
+ * @param extraConfig 表额外 mapper 配置。
+ * @return 启用 L2 缓存的 [DataMapper] 属性委托。
+ */
+inline fun <reified T> cachedMapper(
+    source: Any = DataSource,
+    flags: List<String> = emptyList(),
+    clearFlags: Boolean = false,
+    ssl: String? = null,
+    noinline extraConfig: MapperConfig<T>.() -> Unit = {},
+): ReadOnlyProperty<Any?, DataMapper<T>> {
+    return mapper<T>(source, flags, clearFlags, ssl) {
+        enableDztL2Cache()
+        extraConfig()
+    }
+}
+
+/**
+ * 为 TabooLib mapper 启用 DZT 统一 L2 缓存策略。
+ */
+fun <T> MapperConfig<T>.enableDztL2Cache() {
+    cache {
+        beanCache {
+            maximumSize = BEAN_CACHE_MAXIMUM_SIZE
+            expireAfterAccess = CACHE_EXPIRE_AFTER_ACCESS_SECONDS
+        }
+        queryCache {
+            maximumSize = QUERY_CACHE_MAXIMUM_SIZE
+            expireAfterAccess = CACHE_EXPIRE_AFTER_ACCESS_SECONDS
+        }
+    }
+}

--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/data/table/BackRecord.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/data/table/BackRecord.kt
@@ -1,13 +1,11 @@
-package cn.tj.dzd.mc.dzt.teleport.table
+package cn.tj.dzd.mc.dzt.data.table
 
 import cn.tj.dzd.mc.dzt.data.DataSource
+import cn.tj.dzd.mc.dzt.data.cachedMapper
 import taboolib.expansion.Key
 import taboolib.expansion.Length
-import taboolib.expansion.TableName
-import taboolib.expansion.mapper
 import java.util.UUID
 
-@TableName("back_record")
 data class BackRecord(
     @param:Key
     val uuid: UUID,
@@ -19,4 +17,4 @@ data class BackRecord(
     val y: Double,
     val z: Double,
 )
-val backRecordMapper by mapper<BackRecord>(DataSource)
+val backRecordMapper by cachedMapper<BackRecord>(DataSource)

--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/data/table/HomeRecord.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/data/table/HomeRecord.kt
@@ -1,10 +1,10 @@
-package cn.tj.dzd.mc.dzt.teleport.table
+package cn.tj.dzd.mc.dzt.data.table
 
 import cn.tj.dzd.mc.dzt.data.DataSource
+import cn.tj.dzd.mc.dzt.data.cachedMapper
 import cn.tj.dzd.mc.dzt.util.Icon
 import taboolib.expansion.Key
 import taboolib.expansion.Length
-import taboolib.expansion.mapper
 import java.util.UUID
 
 data class HomeRecord(
@@ -20,4 +20,4 @@ data class HomeRecord(
     val y: Double,
     val z: Double,
 )
-val homeRecordMapper by mapper<HomeRecord>(DataSource)
+val homeRecordMapper by cachedMapper<HomeRecord>(DataSource)

--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/data/table/Money.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/data/table/Money.kt
@@ -1,0 +1,13 @@
+package cn.tj.dzd.mc.dzt.data.table
+
+import cn.tj.dzd.mc.dzt.data.DataSource
+import cn.tj.dzd.mc.dzt.data.cachedMapper
+import taboolib.expansion.Id
+import java.util.UUID
+
+data class Money(
+    @param:Id
+    val uuid: UUID,
+    var ddCoin: Int,
+)
+val moneyMapper by cachedMapper<Money>(DataSource)

--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/data/table/MoneyRecord.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/data/table/MoneyRecord.kt
@@ -1,0 +1,43 @@
+package cn.tj.dzd.mc.dzt.data.table
+
+import cn.tj.dzd.mc.dzt.data.DataSource
+import cn.tj.dzd.mc.dzt.data.cachedMapper
+import taboolib.expansion.IndexedEnum
+import taboolib.expansion.Key
+import taboolib.expansion.Length
+import java.util.UUID
+
+/**
+ * 金钱流水类型。
+ */
+enum class MoneyRecordType(override val index: Long, val desc: String) : IndexedEnum {
+    /** 出账。 */
+    OUT(1, "出账"),
+
+    /** 入账。 */
+    IN(2, "入账"),
+}
+
+/**
+ * 金钱流水记录。
+ *
+ * @property uuid 记录所属玩家 UUID。
+ * @property time 流水发生时间戳，单位为毫秒。
+ * @property type 流水类型。
+ * @property amount 本次变动的 DD Coin 数量。
+ * @property related 关联对象标识，可存玩家 UUID、server、system 等文本。
+ * @property remark 流水备注。
+ */
+data class MoneyRecord(
+    @param:Key
+    val uuid: UUID,
+    @param:Key
+    val time: Long,
+    val type: MoneyRecordType,
+    val amount: Int,
+    @param:Length(64)
+    val related: String?,
+    @param:Length(256)
+    val remark: String?,
+)
+val moneyRecordMapper by cachedMapper<MoneyRecord>(DataSource)

--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/menu/GiveClock.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/menu/GiveClock.kt
@@ -2,6 +2,7 @@ package cn.tj.dzd.mc.dzt.menu
 
 import cn.tj.dzd.mc.dzt.menu.ui.Menu
 import cn.tj.dzd.mc.dzt.util.TextLogo
+import cn.tj.dzd.mc.dzt.util.isBePlayer
 import org.bukkit.Material
 import org.bukkit.entity.Player
 import org.bukkit.event.entity.PlayerDeathEvent
@@ -165,7 +166,7 @@ object GiveClock {
     @SubscribeEvent
     fun onPlayerSwapHandItems(event: PlayerSwapHandItemsEvent) {
         val player = event.player
-        if (!player.isSneaking) {
+        if (!player.isSneaking || player.isBePlayer()) {
             return
         }
 

--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/menu/ui/Menu.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/menu/ui/Menu.kt
@@ -1,6 +1,7 @@
 package cn.tj.dzd.mc.dzt.menu.ui
 
 import cn.tj.dzd.mc.dzt.teleport.ui.Teleport.openTeleport
+import cn.tj.dzd.mc.dzt.money.ui.MoneyUI
 import cn.tj.dzd.mc.dzt.util.TextLogo
 import cn.tj.dzd.mc.dzt.util.foliaPerformCommand
 import cn.tj.dzd.mc.dzt.util.isBePlayer
@@ -58,11 +59,11 @@ object Menu {
             map(
                 "####I####",
                 "#       #",
-                "#   T   #",
+                "#  T E  #",
                 "#       #",
                 "#########"
             )
-            set('#', buildItem(XMaterial.LIGHT_GRAY_STAINED_GLASS_PANE) {
+            set('#', buildItem(XMaterial.GRAY_STAINED_GLASS_PANE) {
                 name = " "
             })
 
@@ -77,19 +78,28 @@ object Menu {
             }) {
                 pl.openTeleport()
             }
+
+            set('E', buildItem(XMaterial.EMERALD) {
+                name = "经济"
+                lore += "查看余额与流水记录"
+            }) {
+                MoneyUI.openMoneyUI(pl)
+            }
         }
     }
     fun be(pl: Player) {
         val fm = SimpleForm.builder()
             .title(TextLogo)
             .button("传送", FormImage.Type.PATH, "textures/ui/csb_purchase_warning.png")
+            .button("经济", FormImage.Type.PATH, "textures/items/emerald.png")
             .button("成就", FormImage.Type.PATH, "textures/ui/achievements_pause_menu_icon.png")
             .validResultHandler { res ->
                 val id = res.clickedButtonId()
 
                 when (id) {
                     0 -> pl.openTeleport()
-                    1 -> pl.foliaPerformCommand("geyser advancements")
+                    1 -> MoneyUI.openMoneyUI(pl)
+                    2 -> pl.foliaPerformCommand("geyser advancements")
                 }
             }
         pl.sendForm(fm)

--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/money/Money.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/money/Money.kt
@@ -1,0 +1,428 @@
+package cn.tj.dzd.mc.dzt.money
+
+import cn.tj.dzd.mc.dzt.data.DatabaseGuard
+import cn.tj.dzd.mc.dzt.data.table.MoneyRecord
+import cn.tj.dzd.mc.dzt.data.table.MoneyRecordType
+import cn.tj.dzd.mc.dzt.data.table.moneyMapper
+import cn.tj.dzd.mc.dzt.data.table.moneyRecordMapper
+import org.bukkit.entity.Player
+import taboolib.expansion.DataMapper
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import cn.tj.dzd.mc.dzt.data.table.Money as MoneyTable
+
+object MoneyService {
+    const val MAX_MONEY_RECORDS = 64
+    private const val MAX_RELATED_LENGTH = 64
+    private const val MAX_REMARK_LENGTH = 256
+
+    private val playerLocks = ConcurrentHashMap<UUID, Any>()
+
+    /**
+     * 获取玩家当前 DD Coin 余额。
+     *
+     * @param player 玩家对象。
+     * @return 玩家余额；数据库读取失败时返回 0。
+     */
+    fun getBalance(player: Player): Int {
+        return getBalance(player.uniqueId)
+    }
+
+    /**
+     * 获取玩家当前 DD Coin 余额。
+     *
+     * @param uuid 玩家 UUID。
+     * @return 玩家余额；数据库读取失败时返回 0。
+     */
+    fun getBalance(uuid: UUID): Int {
+        return DatabaseGuard.execute("获取 DD Coin 余额", 0) {
+            moneyMapper.findMoney(uuid)?.ddCoin ?: 0
+        }
+    }
+
+    /**
+     * 增加玩家 DD Coin。
+     *
+     * 该操作会在同一事务内更新余额、写入入账流水并裁剪旧流水。
+     *
+     * @param player 玩家对象。
+     * @param amount 增加金额，必须大于 0。
+     * @param related 关联对象标识，可存玩家 UUID、server、system 等文本。
+     * @param remark 备注。
+     * @return 是否成功；金额会导致余额溢出或数据库失败时返回 false。
+     */
+    fun increase(player: Player, amount: Int, related: String? = null, remark: String? = null): Boolean {
+        return increase(player.uniqueId, amount, related, remark)
+    }
+
+    /**
+     * 增加玩家 DD Coin。
+     *
+     * 该操作会在同一事务内更新余额、写入入账流水并裁剪旧流水。
+     *
+     * @param uuid 玩家 UUID。
+     * @param amount 增加金额，必须大于 0。
+     * @param related 关联对象标识，可存玩家 UUID、server、system 等文本。
+     * @param remark 备注。
+     * @return 是否成功；金额会导致余额溢出或数据库失败时返回 false。
+     */
+    fun increase(uuid: UUID, amount: Int, related: String? = null, remark: String? = null): Boolean {
+        requirePositiveAmount(amount)
+        val normalizedRelated = normalizeRelated(related)
+        val normalizedRemark = normalizeRemark(remark)
+
+        return withPlayerLocks(uuid) {
+            runMoneyTransaction("增加 DD Coin", false) {
+                val current = findMoney(uuid)
+                val currentBalance = current?.ddCoin ?: 0
+                if (currentBalance > Int.MAX_VALUE - amount) {
+                    return@runMoneyTransaction false
+                }
+
+                saveBalance(uuid, current, currentBalance + amount)
+                appendRecord(uuid, MoneyRecordType.IN, amount, normalizedRelated, normalizedRemark)
+                trimRecords(uuid)
+                true
+            }
+        }
+    }
+
+    /**
+     * 减少玩家 DD Coin。
+     *
+     * 该操作会在同一事务内更新余额、写入出账流水并裁剪旧流水。
+     *
+     * @param player 玩家对象。
+     * @param amount 减少金额，必须大于 0。
+     * @param related 关联对象标识，可存玩家 UUID、server、system 等文本。
+     * @param remark 备注。
+     * @return 是否成功；余额不足或数据库失败时返回 false。
+     */
+    fun decrease(player: Player, amount: Int, related: String? = null, remark: String? = null): Boolean {
+        return decrease(player.uniqueId, amount, related, remark)
+    }
+
+    /**
+     * 减少玩家 DD Coin。
+     *
+     * 该操作会在同一事务内更新余额、写入出账流水并裁剪旧流水。
+     *
+     * @param uuid 玩家 UUID。
+     * @param amount 减少金额，必须大于 0。
+     * @param related 关联对象标识，可存玩家 UUID、server、system 等文本。
+     * @param remark 备注。
+     * @return 是否成功；余额不足或数据库失败时返回 false。
+     */
+    fun decrease(uuid: UUID, amount: Int, related: String? = null, remark: String? = null): Boolean {
+        requirePositiveAmount(amount)
+        val normalizedRelated = normalizeRelated(related)
+        val normalizedRemark = normalizeRemark(remark)
+
+        return withPlayerLocks(uuid) {
+            runMoneyTransaction("减少 DD Coin", false) {
+                val current = findMoney(uuid)
+                val currentBalance = current?.ddCoin ?: 0
+                if (currentBalance < amount) {
+                    return@runMoneyTransaction false
+                }
+
+                saveBalance(uuid, current, currentBalance - amount)
+                appendRecord(uuid, MoneyRecordType.OUT, amount, normalizedRelated, normalizedRemark)
+                trimRecords(uuid)
+                true
+            }
+        }
+    }
+
+    /**
+     * 转账 DD Coin。
+     *
+     * 该操作会在同一事务内扣除转出方余额、增加接收方余额、写入双方流水并裁剪旧流水。
+     *
+     * @param from 转出玩家。
+     * @param to 接收玩家。
+     * @param amount 转账金额，必须大于 0。
+     * @param remark 备注。
+     * @return 是否成功；余额不足、接收方余额溢出或数据库失败时返回 false。
+     */
+    fun transfer(from: Player, to: Player, amount: Int, remark: String? = null): Boolean {
+        return transfer(from.uniqueId, to.uniqueId, amount, remark)
+    }
+
+    /**
+     * 转账 DD Coin。
+     *
+     * 该操作会在同一事务内扣除转出方余额、增加接收方余额、写入双方流水并裁剪旧流水。
+     *
+     * @param from 转出玩家 UUID。
+     * @param to 接收玩家 UUID。
+     * @param amount 转账金额，必须大于 0。
+     * @param remark 备注。
+     * @return 是否成功；余额不足、接收方余额溢出或数据库失败时返回 false。
+     */
+    fun transfer(from: UUID, to: UUID, amount: Int, remark: String? = null): Boolean {
+        require(from != to) { "转账双方不能是同一个玩家" }
+        requirePositiveAmount(amount)
+        val normalizedRemark = normalizeRemark(remark)
+
+        return withPlayerLocks(from, to) {
+            runMoneyTransaction("转账 DD Coin", false) {
+                val fromMoney = findMoney(from)
+                val toMoney = findMoney(to)
+                val fromBalance = fromMoney?.ddCoin ?: 0
+                val toBalance = toMoney?.ddCoin ?: 0
+
+                if (fromBalance < amount || toBalance > Int.MAX_VALUE - amount) {
+                    return@runMoneyTransaction false
+                }
+
+                saveBalance(from, fromMoney, fromBalance - amount)
+                saveBalance(to, toMoney, toBalance + amount)
+                appendRecord(from, MoneyRecordType.OUT, amount, to.toString(), normalizedRemark)
+                appendRecord(to, MoneyRecordType.IN, amount, from.toString(), normalizedRemark)
+                trimRecords(from)
+                trimRecords(to)
+                true
+            }
+        }
+    }
+
+    /**
+     * 获取玩家 DD Coin 流水记录。
+     *
+     * 返回结果按时间倒序排列，最多返回 [MAX_MONEY_RECORDS] 条。
+     *
+     * @param player 玩家对象。
+     * @param limit 返回数量上限，必须大于 0，超过 [MAX_MONEY_RECORDS] 时按 [MAX_MONEY_RECORDS] 处理。
+     * @return 玩家流水记录；数据库读取失败时返回空列表。
+     */
+    fun getRecords(player: Player, limit: Int = MAX_MONEY_RECORDS): List<MoneyRecord> {
+        return getRecords(player.uniqueId, limit)
+    }
+
+    /**
+     * 获取玩家 DD Coin 流水记录。
+     *
+     * 返回结果按时间倒序排列，最多返回 [MAX_MONEY_RECORDS] 条。
+     *
+     * @param uuid 玩家 UUID。
+     * @param limit 返回数量上限，必须大于 0，超过 [MAX_MONEY_RECORDS] 时按 [MAX_MONEY_RECORDS] 处理。
+     * @return 玩家流水记录；数据库读取失败时返回空列表。
+     */
+    fun getRecords(uuid: UUID, limit: Int = MAX_MONEY_RECORDS): List<MoneyRecord> {
+        require(limit > 0) { "流水记录获取数量必须大于 0" }
+        val actualLimit = limit.coerceAtMost(MAX_MONEY_RECORDS)
+
+        return withPlayerLocks(uuid) {
+            runMoneyTransaction("获取 DD Coin 流水", emptyList()) {
+                val records = findSortedRecords(uuid)
+                trimRecords(uuid, records)
+                records.take(actualLimit)
+            }
+        }
+    }
+
+    /**
+     * 清空玩家 DD Coin 流水记录。
+     *
+     * @param player 玩家对象。
+     * @return 是否成功清空；数据库失败时返回 false。
+     */
+    fun clearRecords(player: Player): Boolean {
+        return clearRecords(player.uniqueId)
+    }
+
+    /**
+     * 清空玩家 DD Coin 流水记录。
+     *
+     * @param uuid 玩家 UUID。
+     * @return 是否成功清空；数据库失败时返回 false。
+     */
+    fun clearRecords(uuid: UUID): Boolean {
+        return withPlayerLocks(uuid) {
+            runMoneyTransaction("清空 DD Coin 流水", false) {
+                moneyRecordMapper.deleteWhere {
+                    "uuid" eq uuid.toString()
+                }
+                true
+            }
+        }
+    }
+
+    private fun <T> runMoneyTransaction(action: String, fallback: T, block: DataMapper<MoneyTable>.() -> T): T {
+        return DatabaseGuard.execute(action, fallback) {
+            moneyRecordMapper.tableName
+            moneyMapper.transaction {
+                this.block()
+            }.getOrThrow()
+        }
+    }
+
+    private fun DataMapper<MoneyTable>.findMoney(uuid: UUID): MoneyTable? {
+        return findById(uuid)
+    }
+
+    private fun DataMapper<MoneyTable>.saveBalance(uuid: UUID, current: MoneyTable?, balance: Int) {
+        val money = MoneyTable(uuid, balance)
+        if (current == null) {
+            insert(money)
+        } else {
+            update(money)
+        }
+    }
+
+    private fun appendRecord(
+        uuid: UUID,
+        type: MoneyRecordType,
+        amount: Int,
+        related: String?,
+        remark: String?,
+    ) {
+        moneyRecordMapper.insert(
+            MoneyRecord(
+                uuid = uuid,
+                time = nextRecordTime(uuid),
+                type = type,
+                amount = amount,
+                related = related,
+                remark = remark,
+            )
+        )
+    }
+
+    private fun nextRecordTime(uuid: UUID): Long {
+        val latestTime = findSortedRecords(uuid).maxOfOrNull { it.time }
+        val now = System.currentTimeMillis()
+        return if (latestTime != null && now <= latestTime) latestTime + 1 else now
+    }
+
+    private fun findSortedRecords(uuid: UUID): List<MoneyRecord> {
+        return moneyRecordMapper.findAll {
+            "uuid" eq uuid.toString()
+        }.sortedByDescending { it.time }
+    }
+
+    private fun trimRecords(uuid: UUID, sortedRecords: List<MoneyRecord> = findSortedRecords(uuid)) {
+        sortedRecords
+            .drop(MAX_MONEY_RECORDS)
+            .forEach { record ->
+                moneyRecordMapper.deleteWhere {
+                    "uuid" eq uuid.toString()
+                    "time" eq record.time
+                }
+            }
+    }
+
+    private fun requirePositiveAmount(amount: Int) {
+        require(amount > 0) { "金额必须大于 0" }
+    }
+
+    private fun normalizeRelated(related: String?): String? {
+        return normalizeOptionalText(related, MAX_RELATED_LENGTH, "关联对象")
+    }
+
+    private fun normalizeRemark(remark: String?): String? {
+        return normalizeOptionalText(remark, MAX_REMARK_LENGTH, "备注")
+    }
+
+    private fun normalizeOptionalText(value: String?, maxLength: Int, fieldName: String): String? {
+        val normalized = value?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+        require(normalized.length <= maxLength) { "$fieldName 长度不能超过 $maxLength 个字符" }
+        return normalized
+    }
+
+    private fun <T> withPlayerLocks(vararg uuids: UUID, block: () -> T): T {
+        val locks = uuids
+            .distinct()
+            .sortedBy { it.toString() }
+            .map { uuid -> playerLocks.computeIfAbsent(uuid) { Any() } }
+
+        fun acquire(index: Int): T {
+            return if (index >= locks.size) {
+                block()
+            } else {
+                synchronized(locks[index]) {
+                    acquire(index + 1)
+                }
+            }
+        }
+
+        return acquire(0)
+    }
+}
+
+/**
+ * 获取玩家当前 DD Coin 余额。
+ *
+ * @return 玩家余额；数据库读取失败时返回 0。
+ */
+fun Player.getMoneyBalance(): Int {
+    return MoneyService.getBalance(this)
+}
+
+/**
+ * 增加玩家 DD Coin。
+ *
+ * @param amount 增加金额，必须大于 0。
+ * @param related 关联对象标识，可存玩家 UUID、server、system 等文本。
+ * @param remark 备注。
+ * @return 是否成功；金额会导致余额溢出或数据库失败时返回 false。
+ */
+fun Player.increaseMoney(amount: Int, related: String? = null, remark: String? = null): Boolean {
+    return MoneyService.increase(this, amount, related, remark)
+}
+
+/**
+ * 减少玩家 DD Coin。
+ *
+ * @param amount 减少金额，必须大于 0。
+ * @param related 关联对象标识，可存玩家 UUID、server、system 等文本。
+ * @param remark 备注。
+ * @return 是否成功；余额不足或数据库失败时返回 false。
+ */
+fun Player.decreaseMoney(amount: Int, related: String? = null, remark: String? = null): Boolean {
+    return MoneyService.decrease(this, amount, related, remark)
+}
+
+/**
+ * 向指定玩家转账 DD Coin。
+ *
+ * @param target 接收玩家。
+ * @param amount 转账金额，必须大于 0。
+ * @param remark 备注。
+ * @return 是否成功；余额不足、接收方余额溢出或数据库失败时返回 false。
+ */
+fun Player.transferMoney(target: Player, amount: Int, remark: String? = null): Boolean {
+    return MoneyService.transfer(this, target, amount, remark)
+}
+
+/**
+ * 向指定玩家转账 DD Coin。
+ *
+ * @param target 接收玩家 UUID。
+ * @param amount 转账金额，必须大于 0。
+ * @param remark 备注。
+ * @return 是否成功；余额不足、接收方余额溢出或数据库失败时返回 false。
+ */
+fun Player.transferMoney(target: UUID, amount: Int, remark: String? = null): Boolean {
+    return MoneyService.transfer(uniqueId, target, amount, remark)
+}
+
+/**
+ * 获取玩家 DD Coin 流水记录。
+ *
+ * @param limit 返回数量上限，必须大于 0，超过 64 时按 64 处理。
+ * @return 按时间倒序排列的流水记录；数据库读取失败时返回空列表。
+ */
+fun Player.getMoneyRecords(limit: Int = MoneyService.MAX_MONEY_RECORDS): List<MoneyRecord> {
+    return MoneyService.getRecords(this, limit)
+}
+
+/**
+ * 清空玩家 DD Coin 流水记录。
+ *
+ * @return 是否成功清空；数据库失败时返回 false。
+ */
+fun Player.clearMoneyRecords(): Boolean {
+    return MoneyService.clearRecords(this)
+}

--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/money/ui/MoneyUI.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/money/ui/MoneyUI.kt
@@ -1,0 +1,213 @@
+package cn.tj.dzd.mc.dzt.money.ui
+
+import cn.tj.dzd.mc.dzt.data.table.MoneyRecord
+import cn.tj.dzd.mc.dzt.data.table.MoneyRecordType
+import cn.tj.dzd.mc.dzt.menu.ui.Menu.openMenu
+import cn.tj.dzd.mc.dzt.money.MoneyService
+import cn.tj.dzd.mc.dzt.util.TextLogo
+import cn.tj.dzd.mc.dzt.util.foliaRun
+import cn.tj.dzd.mc.dzt.util.isBePlayer
+import cn.tj.dzd.mc.dzt.util.sendDZTError
+import cn.tj.dzd.mc.dzt.util.sendForm
+import org.bukkit.entity.Player
+import org.geysermc.cumulus.form.ModalForm
+import org.geysermc.cumulus.form.SimpleForm
+import org.geysermc.cumulus.util.FormImage
+import taboolib.library.xseries.XMaterial
+import taboolib.module.ui.openMenu
+import taboolib.module.ui.type.PageableChest
+import taboolib.platform.util.buildItem
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.concurrent.CompletableFuture
+
+object MoneyUI {
+    private val TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+        .withZone(ZoneId.systemDefault())
+
+    /**
+     * 打开经济流水查询界面。
+     *
+     * 会根据玩家客户端类型自动选择 Java 版箱子菜单或基岩版表单菜单。
+     *
+     * @param player 要打开界面的玩家。
+     */
+    fun openMoneyUI(player: Player) {
+        player.foliaRun {
+            val uuid = uniqueId
+            val bedrockPlayer = isBePlayer()
+            val target = this
+
+            CompletableFuture.supplyAsync {
+                MoneyViewData(
+                    balance = MoneyService.getBalance(uuid),
+                    records = MoneyService.getRecords(uuid)
+                )
+            }.whenComplete { data, error ->
+                if (error != null) {
+                    target.foliaRun {
+                        sendDZTError("读取经济流水失败: ${error.message ?: error.javaClass.simpleName}")
+                    }
+                    return@whenComplete
+                }
+
+                target.foliaRun {
+                    if (bedrockPlayer) {
+                        openBedrock(this, data)
+                    } else {
+                        openJava(this, data)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun openJava(player: Player, data: MoneyViewData) {
+        player.openMenu<PageableChest<MoneyRecord>>(TextLogo) {
+            rows(6)
+            virtualize()
+
+            map(
+                "R###M####",
+                "#@@@@@@@#",
+                "#@@@@@@@#",
+                "#@@@@@@@#",
+                "#@@@@@@@#",
+                "###<#>###"
+            )
+
+            onClick(lock = true) {}
+            set('#', XMaterial.GRAY_STAINED_GLASS_PANE) { name = " " }
+            set('M', buildItem(XMaterial.EMERALD) {
+                name = "§l§6经济流水"
+                lore += "§7当前余额: §6${data.balance} §e弟弟币"
+                lore += "§7最多显示最近 ${data.records.size} 条流水"
+            })
+            set('R', buildItem(XMaterial.BARREL) { name = "§l§e返回主菜单" }) {
+                player.openMenu()
+            }
+
+            slotsBy('@')
+            elements { data.records }
+            onGenerate { _, record, _, _ ->
+                buildItem(record.material) {
+                    name = "${record.color}${record.type.desc}: ${record.amount} 弟弟币"
+                    lore += "§7时间: §f${formatTime(record.time)}"
+                    lore += "§7关联: §f${record.related ?: "无"}"
+                    lore += "§7备注: §f${record.remark ?: "无"}"
+                }
+            }
+
+            setPreviousPage(48) { _, hasPrevious ->
+                buildItem(if (hasPrevious) XMaterial.ARROW else XMaterial.GRAY_STAINED_GLASS_PANE) {
+                    name = if (hasPrevious) "§a上一页" else "§7已经是第一页"
+                }
+            }
+            setNextPage(50) { _, hasNext ->
+                buildItem(if (hasNext) XMaterial.ARROW else XMaterial.GRAY_STAINED_GLASS_PANE) {
+                    name = if (hasNext) "§a下一页" else "§7已经是最后一页"
+                }
+            }
+        }
+    }
+
+    private fun openBedrock(player: Player, data: MoneyViewData) {
+        val form = SimpleForm.builder()
+            .title("§l§6经济流水")
+            .content(
+                buildString {
+                    append("§7当前余额: §6${data.balance} §e弟弟币")
+                    if (data.records.isEmpty()) {
+                        append("\n§7暂无流水记录。")
+                    } else {
+                        append("\n§7请选择要查看的流水。")
+                    }
+                }
+            )
+            .button("返回主菜单", FormImage.Type.PATH, "textures/ui/box_ride.png")
+
+        data.records.forEach { record ->
+            form.button(
+                "${record.type.desc}: ${record.amount} 弟弟币\n${formatTime(record.time)}",
+                FormImage.Type.PATH,
+                record.bedrockIcon
+            )
+        }
+
+        form.validResultHandler { response ->
+            val clicked = response.clickedButtonId()
+            if (clicked == 0) {
+                player.foliaRun {
+                    openMenu()
+                }
+                return@validResultHandler
+            }
+
+            val record = data.records.getOrNull(clicked - 1) ?: return@validResultHandler
+            player.foliaRun {
+                openBedrockRecordDetail(this, data, record)
+            }
+        }
+        player.sendForm(form)
+    }
+
+    private fun openBedrockRecordDetail(player: Player, data: MoneyViewData, record: MoneyRecord) {
+        player.sendForm(
+            ModalForm.builder()
+                .title("§l§6流水详情")
+                .content(
+                    buildString {
+                        append("§7类型: ${record.color}${record.type.desc}")
+                        append("\n§7金额: §6${record.amount} §e弟弟币")
+                        append("\n§7时间: §f${formatTime(record.time)}")
+                        append("\n§7关联: §f${record.related ?: "无"}")
+                        append("\n§7备注: §f${record.remark ?: "无"}")
+                    }
+                )
+                .button1("返回流水")
+                .button2("返回主菜单")
+                .validResultHandler { response ->
+                    player.foliaRun {
+                        if (response.clickedButtonId() == 0) {
+                            openBedrock(this, data)
+                        } else {
+                            openMenu()
+                        }
+                    }
+                }
+                .closedOrInvalidResultHandler(Runnable {
+                    player.foliaRun {
+                        openBedrock(this, data)
+                    }
+                })
+        )
+    }
+
+    private fun formatTime(time: Long): String {
+        return TIME_FORMATTER.format(Instant.ofEpochMilli(time))
+    }
+
+    private val MoneyRecord.color: String
+        get() = when (type) {
+            MoneyRecordType.IN -> "§a"
+            MoneyRecordType.OUT -> "§c"
+        }
+
+    private val MoneyRecord.material: XMaterial
+        get() = when (type) {
+            MoneyRecordType.IN -> XMaterial.EMERALD
+            MoneyRecordType.OUT -> XMaterial.REDSTONE
+        }
+
+    private val MoneyRecord.bedrockIcon: String
+        get() = when (type) {
+            MoneyRecordType.IN -> "textures/items/emerald.png"
+            MoneyRecordType.OUT -> "textures/items/redstone_dust.png"
+        }
+}
+
+private data class MoneyViewData(
+    val balance: Int,
+    val records: List<MoneyRecord>,
+)

--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/sidebar/PacketSidebar.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/sidebar/PacketSidebar.kt
@@ -1,0 +1,166 @@
+package cn.tj.dzd.mc.dzt.sidebar
+
+import org.bukkit.entity.Player
+import java.lang.reflect.Constructor
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+import java.util.Optional
+
+internal data class PacketSidebarState(
+    var initialized: Boolean = false,
+    var lineCount: Int = 0,
+)
+
+internal object PacketSidebar {
+    private const val OBJECTIVE_METHOD_ADD = 0
+    private const val OBJECTIVE_METHOD_REMOVE = 1
+    private val bridge by lazy { NmsSidebarBridge() }
+
+    /**
+     * 通过原版记分板包更新玩家侧边栏，避免在 Folia 中调用 Bukkit ScoreboardManager。
+     */
+    fun update(
+        player: Player,
+        objectiveName: String,
+        title: String,
+        lines: List<String>,
+        entries: List<String>,
+        state: PacketSidebarState,
+    ) {
+        if (!state.initialized) {
+            bridge.send(player, bridge.createObjectivePacket(objectiveName, title, OBJECTIVE_METHOD_REMOVE))
+            bridge.send(player, bridge.createObjectivePacket(objectiveName, title, OBJECTIVE_METHOD_ADD))
+            bridge.send(player, bridge.createDisplayObjectivePacket(objectiveName, title))
+            state.initialized = true
+        }
+
+        if (state.lineCount > lines.size) {
+            for (index in lines.size until state.lineCount) {
+                bridge.send(player, bridge.createResetScorePacket(entryAt(entries, index), objectiveName))
+            }
+        }
+
+        lines.forEachIndexed { index, line ->
+            val score = lines.size - index
+            bridge.send(player, bridge.createSetScorePacket(entryAt(entries, index), objectiveName, score, line))
+        }
+
+        state.lineCount = lines.size
+    }
+
+    private fun entryAt(entries: List<String>, index: Int): String {
+        return entries.getOrElse(index) { "dzt_line_$index" }
+    }
+
+    private class NmsSidebarBridge {
+        private val craftPlayerClass = Class.forName("org.bukkit.craftbukkit.entity.CraftPlayer")
+        private val craftChatMessageClass = Class.forName("org.bukkit.craftbukkit.util.CraftChatMessage")
+        private val packetClass = Class.forName("net.minecraft.network.protocol.Packet")
+        private val scoreboardClass = Class.forName("net.minecraft.world.scores.Scoreboard")
+        private val objectiveClass = Class.forName("net.minecraft.world.scores.Objective")
+        private val objectiveCriteriaClass = Class.forName("net.minecraft.world.scores.criteria.ObjectiveCriteria")
+        private val renderTypeClass = Class.forName("net.minecraft.world.scores.criteria.ObjectiveCriteria\$RenderType")
+        private val componentClass = Class.forName("net.minecraft.network.chat.Component")
+        private val numberFormatClass = Class.forName("net.minecraft.network.chat.numbers.NumberFormat")
+        private val displaySlotClass = Class.forName("net.minecraft.world.scores.DisplaySlot")
+        private val setObjectivePacketClass = Class.forName("net.minecraft.network.protocol.game.ClientboundSetObjectivePacket")
+        private val setDisplayObjectivePacketClass = Class.forName("net.minecraft.network.protocol.game.ClientboundSetDisplayObjectivePacket")
+        private val setScorePacketClass = Class.forName("net.minecraft.network.protocol.game.ClientboundSetScorePacket")
+        private val resetScorePacketClass = Class.forName("net.minecraft.network.protocol.game.ClientboundResetScorePacket")
+
+        private val getHandleMethod: Method = craftPlayerClass.getMethod("getHandle")
+        private val fromStringOrEmptyMethod: Method = craftChatMessageClass.getMethod("fromStringOrEmpty", String::class.java)
+        private val connectionField: Field = Class.forName("net.minecraft.server.level.ServerPlayer").getField("connection")
+        private val sendPacketMethod: Method = Class.forName("net.minecraft.server.network.ServerCommonPacketListenerImpl")
+            .getMethod("send", packetClass)
+        private val scoreboardConstructor: Constructor<*> = scoreboardClass.getConstructor()
+        private val objectiveConstructor: Constructor<*> = objectiveClass.getConstructor(
+            scoreboardClass,
+            String::class.java,
+            objectiveCriteriaClass,
+            componentClass,
+            renderTypeClass,
+            Boolean::class.javaPrimitiveType,
+            numberFormatClass,
+        )
+        private val setObjectivePacketConstructor: Constructor<*> = setObjectivePacketClass.getConstructor(
+            objectiveClass,
+            Int::class.javaPrimitiveType,
+        )
+        private val setDisplayObjectivePacketConstructor: Constructor<*> = setDisplayObjectivePacketClass.getConstructor(
+            displaySlotClass,
+            objectiveClass,
+        )
+        private val setScorePacketConstructor: Constructor<*> = setScorePacketClass.getConstructor(
+            String::class.java,
+            String::class.java,
+            Int::class.javaPrimitiveType,
+            Optional::class.java,
+            Optional::class.java,
+        )
+        private val resetScorePacketConstructor: Constructor<*> = resetScorePacketClass.getConstructor(
+            String::class.java,
+            String::class.java,
+        )
+
+        private val dummyCriteria: Any = objectiveCriteriaClass.getField("DUMMY").get(null)
+        private val integerRenderType: Any = renderTypeClass.getField("INTEGER").get(null)
+        private val sidebarDisplaySlot: Any = displaySlotClass.getField("SIDEBAR").get(null)
+        private val blankNumberFormat: Any? = runCatching {
+            Class.forName("net.minecraft.network.chat.numbers.BlankFormat").getField("INSTANCE").get(null)
+        }.getOrNull()
+
+        fun send(player: Player, packet: Any) {
+            val craftPlayer = craftPlayerClass.cast(player)
+            val handle = getHandleMethod.invoke(craftPlayer)
+            val connection = connectionField.get(handle)
+            sendPacketMethod.invoke(connection, packet)
+        }
+
+        fun createObjectivePacket(objectiveName: String, title: String, method: Int): Any {
+            return setObjectivePacketConstructor.newInstance(createObjective(objectiveName, title), method)
+        }
+
+        fun createDisplayObjectivePacket(objectiveName: String, title: String): Any {
+            return setDisplayObjectivePacketConstructor.newInstance(sidebarDisplaySlot, createObjective(objectiveName, title))
+        }
+
+        fun createSetScorePacket(owner: String, objectiveName: String, score: Int, display: String): Any {
+            return setScorePacketConstructor.newInstance(
+                owner,
+                objectiveName,
+                score,
+                Optional.of(component(display)),
+                numberFormatOptional(),
+            )
+        }
+
+        fun createResetScorePacket(owner: String, objectiveName: String): Any {
+            return resetScorePacketConstructor.newInstance(owner, objectiveName)
+        }
+
+        private fun createObjective(objectiveName: String, title: String): Any {
+            return objectiveConstructor.newInstance(
+                scoreboardConstructor.newInstance(),
+                objectiveName,
+                dummyCriteria,
+                component(title),
+                integerRenderType,
+                false,
+                blankNumberFormat,
+            )
+        }
+
+        private fun component(text: String): Any {
+            return fromStringOrEmptyMethod.invoke(null, text)
+        }
+
+        private fun numberFormatOptional(): Optional<*> {
+            return if (blankNumberFormat == null) {
+                Optional.empty<Any>()
+            } else {
+                Optional.of(blankNumberFormat)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/sidebar/Sidebar.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/sidebar/Sidebar.kt
@@ -1,0 +1,159 @@
+package cn.tj.dzd.mc.dzt.sidebar
+
+import cn.tj.dzd.mc.dzt.money.MoneyService
+import cn.tj.dzd.mc.dzt.util.TextLogo
+import cn.tj.dzd.mc.dzt.util.foliaRun
+import cn.tj.dzd.mc.dzt.util.isBePlayer
+import cn.tj.dzd.mc.dzt.util.networkPing
+import org.bukkit.Bukkit
+import org.bukkit.entity.Player
+import org.bukkit.event.player.PlayerJoinEvent
+import org.bukkit.event.player.PlayerQuitEvent
+import taboolib.common.LifeCycle
+import taboolib.common.platform.Awake
+import taboolib.common.platform.event.SubscribeEvent
+import taboolib.common.platform.function.severe
+import taboolib.common.platform.function.submit
+import taboolib.common.platform.service.PlatformExecutor
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+object Sidebar {
+    private const val SERVER_QQ_GROUP = "747121127"
+    private const val OBJECTIVE_NAME = "dzt_sidebar"
+    private const val PLAYER_SYNC_PERIOD_TICKS = 20L
+    private const val UPDATE_PERIOD_TICKS = 100L
+
+    private var playerSyncTask: PlatformExecutor.PlatformTask? = null
+    private val sidebarTasks = ConcurrentHashMap<UUID, PlatformExecutor.PlatformTask>()
+    private val sidebarStates = ConcurrentHashMap<UUID, PacketSidebarState>()
+    private val lineEntries = listOf("§0", "§1", "§2", "§3", "§4", "§5", "§6", "§7", "§8", "§9")
+
+    /**
+     * 启动侧边栏在线玩家同步任务。
+     *
+     * 同步任务会周期性补齐已在线玩家的侧边栏刷新任务，避免只依赖进服事件导致玩家没有侧边栏。
+     */
+    @Awake(LifeCycle.ACTIVE)
+    fun start() {
+        if (playerSyncTask != null) {
+            return
+        }
+
+        syncOnlinePlayers()
+        playerSyncTask = submit(delay = 1L, period = PLAYER_SYNC_PERIOD_TICKS) {
+            syncOnlinePlayers()
+        }
+    }
+
+    /**
+     * 插件卸载时取消所有侧边栏刷新任务。
+     */
+    @Awake(LifeCycle.DISABLE)
+    fun stop() {
+        playerSyncTask?.cancel()
+        playerSyncTask = null
+        sidebarTasks.values.forEach { it.cancel() }
+        sidebarTasks.clear()
+        sidebarStates.clear()
+    }
+
+    /**
+     * 玩家进入服务器时启动侧边栏刷新任务。
+     */
+    @SubscribeEvent
+    fun onPlayerJoin(event: PlayerJoinEvent) {
+        startSidebarTask(event.player)
+    }
+
+    /**
+     * 玩家离开服务器时取消侧边栏刷新任务。
+     */
+    @SubscribeEvent
+    fun onPlayerQuit(event: PlayerQuitEvent) {
+        val uuid = event.player.uniqueId
+        sidebarTasks.remove(uuid)?.cancel()
+        sidebarStates.remove(uuid)
+    }
+
+    private fun syncOnlinePlayers() {
+        val onlinePlayers = Bukkit.getOnlinePlayers()
+        val onlineIds = onlinePlayers.mapTo(mutableSetOf()) { it.uniqueId }
+
+        sidebarTasks.keys
+            .filter { it !in onlineIds }
+            .forEach {
+                sidebarTasks.remove(it)?.cancel()
+                sidebarStates.remove(it)
+            }
+
+        onlinePlayers.forEach { player ->
+            if (!sidebarTasks.containsKey(player.uniqueId)) {
+                startSidebarTask(player)
+            }
+        }
+    }
+
+    private fun startSidebarTask(player: Player) {
+        val uuid = player.uniqueId
+        sidebarTasks.remove(uuid)?.cancel()
+        sidebarStates.remove(uuid)
+        sidebarTasks[uuid] = submit(async = true, delay = 1L, period = UPDATE_PERIOD_TICKS) {
+            refreshSidebar(player, uuid)
+        }
+    }
+
+    private fun refreshSidebar(player: Player, uuid: UUID) {
+        if (!player.isOnline) {
+            sidebarTasks.remove(uuid)?.cancel()
+            return
+        }
+
+        runCatching {
+            val balance = MoneyService.getBalance(uuid)
+            player.foliaRun {
+                updateSidebar(balance)
+            }.whenComplete { success, error ->
+                if (error != null) {
+                    sidebarTasks.remove(uuid)?.cancel()
+                    severe(
+                        "侧边栏刷新失败。",
+                        "玩家 UUID: $uuid",
+                        error.stackTraceToString()
+                    )
+                    return@whenComplete
+                }
+
+                if (!success) {
+                    sidebarTasks.remove(uuid)?.cancel()
+                }
+            }
+        }.onFailure {
+            sidebarTasks.remove(uuid)?.cancel()
+            throw it
+        }
+    }
+
+    private fun Player.updateSidebar(balance: Int) {
+        val sidebarLines = buildSidebarLines(balance)
+        val state = sidebarStates.computeIfAbsent(uniqueId) { PacketSidebarState() }
+        PacketSidebar.update(this, OBJECTIVE_NAME, TextLogo, sidebarLines, lineEntries, state)
+    }
+
+    private fun Player.buildSidebarLines(balance: Int): List<String> {
+        val bedrockPlayer = isBePlayer()
+        val ping = networkPing().coerceAtLeast(0)
+
+        return buildList {
+            add("")
+            add("§e弟弟币: §6$balance")
+            add("§ePing: §a${ping}ms${if (bedrockPlayer) " §7BE" else ""}")
+            add("")
+            add("§7QQ: $SERVER_QQ_GROUP")
+
+            if (!bedrockPlayer) {
+                add("§7Shift+F 打开菜单")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/teleport/service/Back.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/teleport/service/Back.kt
@@ -1,8 +1,8 @@
 package cn.tj.dzd.mc.dzt.teleport.service
 
 import cn.tj.dzd.mc.dzt.data.DatabaseGuard
-import cn.tj.dzd.mc.dzt.teleport.table.BackRecord
-import cn.tj.dzd.mc.dzt.teleport.table.backRecordMapper
+import cn.tj.dzd.mc.dzt.data.table.BackRecord
+import cn.tj.dzd.mc.dzt.data.table.backRecordMapper
 import cn.tj.dzd.mc.dzt.util.foliaTeleport
 import org.bukkit.Location
 import org.bukkit.entity.Player
@@ -24,7 +24,7 @@ data class DTPBack(
 )
 
 object BackService {
-    private const val MAX_BACK_RECORDS = 16
+    private const val MAX_BACK_RECORDS = 32
 
     @SubscribeEvent
     fun onPlayerDeath(event: PlayerDeathEvent) {

--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/teleport/service/Home.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/teleport/service/Home.kt
@@ -1,8 +1,8 @@
 package cn.tj.dzd.mc.dzt.teleport.service
 
 import cn.tj.dzd.mc.dzt.data.DatabaseGuard
-import cn.tj.dzd.mc.dzt.teleport.table.HomeRecord
-import cn.tj.dzd.mc.dzt.teleport.table.homeRecordMapper
+import cn.tj.dzd.mc.dzt.data.table.HomeRecord
+import cn.tj.dzd.mc.dzt.data.table.homeRecordMapper
 import cn.tj.dzd.mc.dzt.util.Icon
 import cn.tj.dzd.mc.dzt.util.foliaTeleport
 import org.bukkit.Location

--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/util/Floodgate.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/util/Floodgate.kt
@@ -1,6 +1,7 @@
 package cn.tj.dzd.mc.dzt.util
 
 import org.bukkit.entity.Player
+import org.geysermc.geyser.api.GeyserApi
 import org.geysermc.cumulus.form.Form
 import org.geysermc.cumulus.form.SimpleForm
 import org.geysermc.cumulus.form.util.FormBuilder
@@ -13,6 +14,24 @@ var floodgateApi = FloodgateApi.getInstance()
  */
 fun Player.isBePlayer(): Boolean {
     return floodgateApi.isFloodgatePlayer(uniqueId)
+}
+
+/**
+ * 获取玩家网络延迟。
+ *
+ * Java 玩家使用 Bukkit/Paper 的 ping；基岩版玩家优先使用 Geyser 会话 ping，
+ * 避免只看到 Floodgate/Geyser 到 Java 服务端之间的本地延迟。
+ *
+ * @return 玩家延迟，单位为毫秒；Geyser 会话不可用时回退到 Bukkit/Paper ping。
+ */
+fun Player.networkPing(): Int {
+    if (!isBePlayer()) {
+        return ping
+    }
+
+    return runCatching {
+        GeyserApi.api().connectionByUuid(uniqueId)?.ping()
+    }.getOrNull() ?: ping
 }
 
 /**


### PR DESCRIPTION
- 新增 DD Coin 余额、流水记录、转账、增减、清空流水等经济业务
- 为经济流水增加金额、时间戳、关联对象与备注字段
- 接入经济流水查询 UI，并区分 Java / 基岩玩家展示
- 实现 Folia 兼容侧边栏，显示 QQ 群、余额与网络延迟
- 基岩玩家延迟优先读取 Geyser 会话 ping
- 为数据库 mapper 启用 TabooLib L2 双层缓存
- 修复 MoneyRecord 构造参数映射与侧边栏 Folia scoreboard 异常