### PR TITLE
feat: 完善称号系统与玩家数据持久化

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md
+## 项目概述
+DZT 是 DZD JE-BE 互通服的核心插件，服务器所有功能都由此插件提供。
+
+## 技术栈
+TabooLib - https://taboolib.maplex.top/docs/intro
+Folia 26.1.2 - https://jd.papermc.io/folia/26.1.2/
+Geyser - https://github.com/GeyserMC/Geyser
+Floodgate - https://github.com/GeyserMC/Floodgate
+ServiceIO - https://github.com/TheNextLvl-net/service-io
+
+## 开发注意事项
+- 所有接口都需附带调用注释，便于他人使用
+- 对于常用代码，应封装为接口，便于复用
+- 编写 UI 时需单独为 Java 玩家制作箱子 UI，基岩玩家制作表单 UI
+- 获取 Java 玩家的文本，选项，滑块等输入时，优先使用 Paper Dialogs API - https://docs.papermc.io/paper/dev/dialogs/
+- 所有表单 UI 按钮必须附带图标
+- 在与游戏交互时仔细检查 Folia 兼容
+- 调用接口时先确认TabooLib是否提供的更简易的替代
+
+## 关于数据存储
+数据存储位于 data 目录。分别对接 MySQL、 Redis。
+严禁在代码中修改数据库结构，数据库操作统一使用 https://taboolib.maplex.top/docs/expanding-technology/persistent-container/ 
+需要更改数据库结构时请告知人类，由人工手动更新数据库。

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/chat/ChatEnhancement.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/chat/ChatEnhancement.kt
@@ -1,0 +1,62 @@
+package cn.tj.dzd.mc.dzt.chat
+
+import cn.tj.dzd.mc.dzt.title.TitleService
+import cn.tj.dzd.mc.dzt.util.isBePlayer
+import cn.tj.dzd.mc.dzt.util.networkPing
+import io.papermc.paper.chat.ChatRenderer
+import io.papermc.paper.event.player.AsyncChatEvent
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.NamedTextColor
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer
+import taboolib.common.platform.event.EventPriority
+import taboolib.common.platform.event.SubscribeEvent
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+/**
+ * 全服聊天格式增强。
+ *
+ * 格式：`[time] JE/BE | 42ms <[称号]DisplayName> message`。
+ */
+object ChatEnhancement {
+
+    private val beijingZone: ZoneId = ZoneId.of("Asia/Shanghai")
+    private val timeFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss")
+    private val legacySerializer = LegacyComponentSerializer.legacySection()
+
+    @SubscribeEvent(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    fun onAsyncChat(event: AsyncChatEvent) {
+        val player = event.player
+        val time = LocalTime.now(beijingZone).format(timeFormatter)
+        val client = if (player.isBePlayer()) "BE" else "JE"
+        val ping = player.networkPing().coerceAtLeast(0)
+        val title = TitleService.getCachedEquippedTitle(player.uniqueId)
+        val titleComponent = title?.let {
+            Component.text("[", NamedTextColor.YELLOW)
+                .append(legacySerializer.deserialize(it.displayName).colorIfAbsent(NamedTextColor.YELLOW))
+                .append(Component.text("]", NamedTextColor.YELLOW))
+        } ?: Component.empty()
+
+        event.renderer(
+            ChatRenderer.viewerUnaware { _, sourceDisplayName, message ->
+                Component.empty()
+                    .append(Component.text("[$time]", NamedTextColor.GRAY))
+                    .append(Component.space())
+                    .append(
+                        Component.text(
+                            client,
+                            if (client == "BE") NamedTextColor.LIGHT_PURPLE else NamedTextColor.GREEN
+                        )
+                    )
+                    .append(Component.text(" | ", NamedTextColor.GRAY))
+                    .append(Component.text("${ping}ms", NamedTextColor.GREEN))
+                    .append(Component.text(" <", NamedTextColor.GOLD))
+                    .append(titleComponent)
+                    .append(sourceDisplayName.colorIfAbsent(NamedTextColor.WHITE))
+                    .append(Component.text("> ", NamedTextColor.GOLD))
+                    .append(message.colorIfAbsent(NamedTextColor.WHITE))
+            }
+        )
+    }
+}

--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/data/table/PlayerLogRecord.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/data/table/PlayerLogRecord.kt
@@ -1,0 +1,21 @@
+package cn.tj.dzd.mc.dzt.data.table
+
+import cn.tj.dzd.mc.dzt.data.DataSource
+import cn.tj.dzd.mc.dzt.data.cachedMapper
+import taboolib.expansion.Length
+import taboolib.expansion.TableName
+
+/**
+ * 玩家行为日志记录。
+ *
+ * `time` 由数据库默认值生成，因此数据类只映射业务写入的 `type` 与 `msg` 字段。
+ */
+@TableName("player_log")
+data class PlayerLogRecord(
+    @param:Length(32)
+    val type: String,
+    @param:Length(128)
+    val msg: String,
+)
+
+val playerLogMapper by cachedMapper<PlayerLogRecord>(DataSource)

--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/data/table/PlayerTitleRecord.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/data/table/PlayerTitleRecord.kt
@@ -1,0 +1,34 @@
+package cn.tj.dzd.mc.dzt.data.table
+
+import cn.tj.dzd.mc.dzt.data.DataSource
+import cn.tj.dzd.mc.dzt.data.cachedMapper
+import taboolib.expansion.Id
+import taboolib.expansion.Key
+import taboolib.expansion.Length
+import taboolib.expansion.TableName
+import taboolib.expansion.UniqueKey
+import java.util.UUID
+
+/**
+ * 玩家已拥有称号的持久化记录。
+ *
+ * [recordId] 由玩家 UUID 与标准化后的称号 ID 组成，用于防止同一玩家重复获得同一称号。
+ */
+data class PlayerTitleRecord(
+    @param:Id
+    @param:UniqueKey
+    @param:Length(128)
+    val recordId: String,
+    @param:Key
+    val uuid: UUID,
+    @param:Length(64)
+    val titleId: String,
+    @param:Length(64)
+    val displayName: String,
+    @param:Length(256)
+    val description: String,
+    val acquiredAt: Long,
+    var equipped: Boolean,
+)
+
+val playerTitleRecordMapper by cachedMapper<PlayerTitleRecord>(DataSource)

--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/data/table/PreferredRouteRecord.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/data/table/PreferredRouteRecord.kt
@@ -1,0 +1,15 @@
+package cn.tj.dzd.mc.dzt.data.table
+
+import cn.tj.dzd.mc.dzt.data.DataSource
+import cn.tj.dzd.mc.dzt.data.cachedMapper
+import taboolib.expansion.Id
+import taboolib.expansion.TableName
+import java.util.UUID
+
+@TableName("preferred_route")
+data class PreferredRouteRecord(
+    @param:Id
+    val uuid: UUID,
+)
+
+val preferredRouteRecordMapper by cachedMapper<PreferredRouteRecord>(DataSource)

--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/log/PlayerLogService.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/log/PlayerLogService.kt
@@ -1,0 +1,128 @@
+package cn.tj.dzd.mc.dzt.log
+
+import cn.tj.dzd.mc.dzt.data.DatabaseGuard
+import cn.tj.dzd.mc.dzt.data.table.PlayerLogRecord
+import cn.tj.dzd.mc.dzt.data.table.playerLogMapper
+import cn.tj.dzd.mc.dzt.util.networkPing
+import io.papermc.paper.event.player.AsyncChatEvent
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer
+import org.bukkit.entity.Player
+import org.bukkit.event.entity.PlayerDeathEvent
+import org.bukkit.event.player.PlayerJoinEvent
+import org.bukkit.event.player.PlayerQuitEvent
+import taboolib.common.LifeCycle
+import taboolib.common.platform.Awake
+import taboolib.common.platform.event.EventPriority
+import taboolib.common.platform.event.SubscribeEvent
+import java.sql.Timestamp
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
+
+/**
+ * 玩家行为日志服务。
+ *
+ * 日志表由外部数据库迁移创建，本服务只负责写入 `type`、`msg` 两列，`time` 使用数据库默认值。
+ * 所有数据库操作都在单独的串行线程中执行，避免阻塞 Bukkit/Folia 的玩家线程。
+ */
+object PlayerLogService {
+
+    private const val LOG_RETENTION_DAYS = 30L
+    private const val MAX_MESSAGE_LENGTH = 128
+    private val plainTextSerializer = PlainTextComponentSerializer.plainText()
+    private val executor: ExecutorService = Executors.newSingleThreadExecutor { runnable ->
+        Thread(runnable, "DZT-PlayerLog").apply { isDaemon = true }
+    }
+
+    /**
+     * 插件启用时清理超过 30 天的日志。
+     */
+    @Awake(LifeCycle.ACTIVE)
+    fun cleanupExpiredLogsOnStartup() {
+        enqueue("清理玩家日志") {
+            val cutoff = Timestamp.from(Instant.now().minus(LOG_RETENTION_DAYS, ChronoUnit.DAYS))
+            val deleted = playerLogMapper.rawDelete {
+                // ActionDelete 必须通过 where 挂载过滤条件，否则会生成无条件 DELETE。
+                where {
+                    "time" lt cutoff
+                }
+            }
+            taboolib.common.platform.function.info("玩家日志清理完成，删除 $deleted 条超过 ${LOG_RETENTION_DAYS} 天的记录。")
+        }
+    }
+
+    /**
+     * 插件关闭时停止日志队列。
+     */
+    @Awake(LifeCycle.DISABLE)
+    fun close() {
+        executor.shutdownNow()
+    }
+
+    /**
+     * 记录玩家聊天内容。仅记录未被取消的聊天事件。
+     */
+    @SubscribeEvent(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    fun onPlayerChat(event: AsyncChatEvent) {
+        val message = plainTextSerializer.serialize(event.message())
+        record(event.player, "说话", "内容：$message")
+    }
+
+    /**
+     * 记录玩家死亡信息。
+     */
+    @SubscribeEvent
+    fun onPlayerDeath(event: PlayerDeathEvent) {
+        val deathMessage = event.deathMessage()
+            ?.let(plainTextSerializer::serialize)
+            ?.takeIf(String::isNotBlank)
+        record(event.entity, "死亡", deathMessage?.let { "死亡信息：$it" } ?: "玩家死亡")
+    }
+
+    /**
+     * 记录玩家进入服务器。
+     */
+    @SubscribeEvent
+    fun onPlayerJoin(event: PlayerJoinEvent) {
+        record(event.player, "进入服务器", "玩家进入服务器")
+    }
+
+    /**
+     * 记录玩家离开服务器。
+     */
+    @SubscribeEvent
+    fun onPlayerQuit(event: PlayerQuitEvent) {
+        record(event.player, "离开服务器", "玩家离开服务器")
+    }
+
+    private fun record(player: Player, type: String, detail: String) {
+        val ping = runCatching { player.networkPing() }
+            .getOrDefault(0)
+            .coerceAtLeast(0)
+        val message = buildMessage(player, ping, detail)
+
+        enqueue("新增玩家日志") {
+            playerLogMapper.insert(PlayerLogRecord(type, message))
+        }
+    }
+
+    private fun buildMessage(player: Player, ping: Int, detail: String): String {
+        val normalizedDetail = detail.replace('\n', ' ').replace('\r', ' ')
+        return "玩家名称：${player.name}，UUID：${player.uniqueId}，Ping：${ping}ms；$normalizedDetail"
+            .take(MAX_MESSAGE_LENGTH)
+    }
+
+    private fun enqueue(action: String, block: () -> Unit) {
+        try {
+            executor.execute {
+                DatabaseGuard.execute(action) {
+                    block()
+                }
+            }
+        } catch (_: RejectedExecutionException) {
+            // 插件关闭后不再接受新的日志任务。
+        }
+    }
+}

--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/menu/ui/Menu.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/menu/ui/Menu.kt
@@ -2,6 +2,7 @@ package cn.tj.dzd.mc.dzt.menu.ui
 
 import cn.tj.dzd.mc.dzt.teleport.ui.Teleport.openTeleport
 import cn.tj.dzd.mc.dzt.economy.ui.TransferUI
+import cn.tj.dzd.mc.dzt.title.ui.TitleUI
 import cn.tj.dzd.mc.dzt.util.TextLogo
 import cn.tj.dzd.mc.dzt.util.foliaPerformCommand
 import cn.tj.dzd.mc.dzt.util.foliaRun
@@ -61,7 +62,7 @@ object Menu {
             map(
                 "####I####",
                 "#       #",
-                "#  T E  #",
+                "# T E C #",
                 "#   S   #",
                 "#########"
             )
@@ -88,6 +89,13 @@ object Menu {
                 TransferUI.openTransferUI(pl)
             }
 
+            set('C', buildItem(XMaterial.NAME_TAG) {
+                name = "称号"
+                lore += "选择已拥有的称号"
+            }) {
+                TitleUI.open(pl)
+            }
+
             set('S', buildItem(XMaterial.WITHER_SKELETON_SKULL) {
                 name = "§l§c自杀"
                 lore += "§7结束当前生命"
@@ -102,6 +110,7 @@ object Menu {
             .title(TextLogo)
             .button("传送", FormImage.Type.PATH, "textures/ui/csb_purchase_warning.png")
             .button("转账", FormImage.Type.PATH, "textures/items/emerald.png")
+            .button("称号", FormImage.Type.PATH, "textures/items/name_tag.png")
             .button("成就", FormImage.Type.PATH, "textures/ui/achievements_pause_menu_icon.png")
             .button("自杀", FormImage.Type.PATH, "textures/ui/warning_sad_steve.png")
             .validResultHandler { res ->
@@ -110,8 +119,9 @@ object Menu {
                 when (id) {
                     0 -> pl.openTeleport()
                     1 -> TransferUI.openTransferUI(pl)
-                    2 -> pl.foliaPerformCommand("geyser advancements")
-                    3 -> openBedrockSuicideConfirmation(pl)
+                    2 -> TitleUI.open(pl)
+                    3 -> pl.foliaPerformCommand("geyser advancements")
+                    4 -> openBedrockSuicideConfirmation(pl)
                 }
             }
         pl.sendForm(fm)

--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/route/PreferredRouteService.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/route/PreferredRouteService.kt
@@ -1,0 +1,122 @@
+package cn.tj.dzd.mc.dzt.route
+
+import cn.tj.dzd.mc.dzt.data.DatabaseGuard
+import cn.tj.dzd.mc.dzt.data.config
+import cn.tj.dzd.mc.dzt.data.table.preferredRouteRecordMapper
+import cn.tj.dzd.mc.dzt.teleport.ui.sendTeleportSuccess
+import cn.tj.dzd.mc.dzt.util.DEFAULT_FOLIA_TELEPORT_SOUND
+import cn.tj.dzd.mc.dzt.util.foliaPlaySound
+import cn.tj.dzd.mc.dzt.util.foliaRun
+import cn.tj.dzd.mc.dzt.util.isBePlayer
+import org.bukkit.entity.Player
+import org.bukkit.event.player.PlayerJoinEvent
+import taboolib.common.platform.event.SubscribeEvent
+import taboolib.expansion.DurationType
+import taboolib.expansion.submitChain
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+
+object PreferredRouteService {
+    private const val JAVA_PORT = 26111
+    private const val BEDROCK_PORT = 36332
+    private const val ROUTE_COOLDOWN_MILLIS = 30_000L
+
+    private val routeCooldowns = mutableMapOf<UUID, Long>()
+
+    @SubscribeEvent
+    fun onPlayerJoin(event: PlayerJoinEvent) {
+        val player = event.player
+        val targetIp = config.getString("preferred-route.ip", "")?.trim().orEmpty()
+        if (targetIp.isEmpty()) {
+            return
+        }
+
+        CompletableFuture.supplyAsync {
+            isPreferredPlayer(player.uniqueId)
+        }.whenComplete { preferred, error ->
+            if (error != null || preferred != true || !player.isOnline) {
+                return@whenComplete
+            }
+            val now = System.currentTimeMillis()
+            val canTransfer = synchronized(routeCooldowns) {
+                val lastTransfer = routeCooldowns[player.uniqueId]
+                if (lastTransfer != null && now - lastTransfer < ROUTE_COOLDOWN_MILLIS) {
+                    false
+                } else {
+                    routeCooldowns[player.uniqueId] = now
+                    true
+                }
+            }
+            if (!canTransfer) {
+                return@whenComplete
+            }
+            player.foliaRun {
+                transfer(player, targetIp)
+            }
+        }
+    }
+
+    fun isPreferredPlayer(uuid: UUID): Boolean {
+        return DatabaseGuard.execute("查询优选线路玩家", false) {
+            preferredRouteRecordMapper.findOne {
+                "uuid" eq uuid.toString()
+            } != null
+        }
+    }
+
+    private fun transfer(player: Player, targetIp: String) {
+        submitChain {
+            if (player.isBePlayer()) {
+                wait(1000 * 3, DurationType.MILLIS)
+            }
+            sync {
+                player.sendTeleportSuccess("尊敬的优选用户，您将于 6 秒后重定向至优选线路！")
+                player.foliaPlaySound(DEFAULT_FOLIA_TELEPORT_SOUND, pitch = 0.65f)
+            }
+
+            wait(1000, DurationType.MILLIS)
+
+            sync {
+                player.foliaPlaySound(DEFAULT_FOLIA_TELEPORT_SOUND, pitch = 0.65f)
+            }
+
+            wait(1000, DurationType.MILLIS)
+
+            sync {
+                player.foliaPlaySound(DEFAULT_FOLIA_TELEPORT_SOUND, pitch = 0.65f)
+            }
+
+            wait(1000, DurationType.MILLIS)
+
+            sync {
+                player.foliaPlaySound(DEFAULT_FOLIA_TELEPORT_SOUND, pitch = 0.65f)
+            }
+
+            wait(1000, DurationType.MILLIS)
+
+            sync {
+                player.foliaPlaySound(DEFAULT_FOLIA_TELEPORT_SOUND, pitch = 0.65f)
+            }
+
+            wait(1000, DurationType.MILLIS)
+
+            sync {
+                player.foliaPlaySound(DEFAULT_FOLIA_TELEPORT_SOUND, pitch = 0.65f)
+            }
+
+            wait(1000, DurationType.MILLIS)
+
+            sync {
+                if (player.isBePlayer()) {
+                    runCatching {
+                        org.geysermc.geyser.api.GeyserApi.api()
+                            .connectionByUuid(player.uniqueId)
+                            ?.transfer(targetIp, BEDROCK_PORT)
+                    }
+                } else {
+                    player.transfer(targetIp, JAVA_PORT)
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/title/PlayerTitle.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/title/PlayerTitle.kt
@@ -1,0 +1,45 @@
+package cn.tj.dzd.mc.dzt.title
+
+/**
+ * 对外展示的玩家称号。
+ *
+ * @param id 称号的稳定唯一标识。
+ * @param displayName 称号显示名，支持 `§` 颜色代码。
+ * @param description 称号介绍。
+ * @param acquiredAt 称号授予玩家时的 Unix 毫秒时间戳。
+ * @param equipped 玩家当前是否正在佩戴该称号。
+ */
+data class PlayerTitle(
+    val id: String,
+    val displayName: String,
+    val description: String,
+    val acquiredAt: Long,
+    val equipped: Boolean,
+) {
+    /** 称号授予时间戳，与 [acquiredAt] 为同一值。 */
+    val grantedAt: Long
+        get() = acquiredAt
+}
+
+/** 授予称号的处理结果。 */
+enum class TitleGrantResult {
+    GRANTED,
+    ALREADY_OWNED,
+    FAILED,
+}
+
+/** 移除玩家称号的处理结果。 */
+enum class TitleRevokeResult {
+    REVOKED,
+    NOT_OWNED,
+    FAILED,
+}
+
+/** 更改玩家佩戴称号的处理结果。 */
+enum class TitleEquipResult {
+    EQUIPPED,
+    UNEQUIPPED,
+    ALREADY_EQUIPPED,
+    NOT_OWNED,
+    FAILED,
+}

--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/title/TitleApi.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/title/TitleApi.kt
@@ -1,0 +1,150 @@
+package cn.tj.dzd.mc.dzt.title
+
+import org.bukkit.entity.Player
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+
+/**
+ * 称号系统对外 API。
+ *
+ * 所有方法均在异步线程访问数据库，调用方可通过返回的 [CompletableFuture] 处理结果。
+ */
+object TitleApi {
+
+    /**
+     * 授予玩家一个称号。
+     *
+     * 称号不会被自动佩戴，成功授予时会自动记录当前 Unix 毫秒时间戳。
+     * 非法参数会令 Future 异常完成，数据库失败则返回 [TitleGrantResult.FAILED]。
+     *
+     * @param playerUuid 获得称号的玩家 UUID。
+     * @param titleId 稳定的称号 ID，允许小写字母、数字、点、下划线与连字符。
+     * @param displayName 称号显示名，支持 `§` 颜色代码。
+     * @param description 称号介绍，最多 256 个字符。
+     * @return 异步授予结果。
+     */
+    @JvmStatic
+    fun grantTitle(
+        playerUuid: UUID,
+        titleId: String,
+        displayName: String,
+        description: String,
+    ): CompletableFuture<TitleGrantResult> {
+        return CompletableFuture.supplyAsync {
+            TitleService.grantTitle(playerUuid, titleId, displayName, description)
+        }
+    }
+
+    /**
+     * 授予玩家一个无介绍的称号。
+     *
+     * 保留该重载用于兼容已有调用方。
+     *
+     * @param playerUuid 获得称号的玩家 UUID。
+     * @param titleId 稳定的称号 ID。
+     * @param displayName 称号显示名。
+     * @return 异步授予结果。
+     */
+    @JvmStatic
+    fun grantTitle(
+        playerUuid: UUID,
+        titleId: String,
+        displayName: String,
+    ): CompletableFuture<TitleGrantResult> {
+        return grantTitle(playerUuid, titleId, displayName, "")
+    }
+
+    /**
+     * 授予在线玩家一个称号。
+     *
+     * @param player 获得称号的玩家。
+     * @param titleId 稳定的称号 ID。
+     * @param displayName 称号显示名，支持 `§` 颜色代码。
+     * @param description 称号介绍，最多 256 个字符。
+     * @return 异步授予结果。
+     */
+    @JvmStatic
+    fun grantTitle(
+        player: Player,
+        titleId: String,
+        displayName: String,
+        description: String,
+    ): CompletableFuture<TitleGrantResult> {
+        return grantTitle(player.uniqueId, titleId, displayName, description)
+    }
+
+    /**
+     * 授予在线玩家一个无介绍的称号。
+     *
+     * @param player 获得称号的玩家。
+     * @param titleId 稳定的称号 ID。
+     * @param displayName 称号显示名。
+     * @return 异步授予结果。
+     */
+    @JvmStatic
+    fun grantTitle(
+        player: Player,
+        titleId: String,
+        displayName: String,
+    ): CompletableFuture<TitleGrantResult> {
+        return grantTitle(player.uniqueId, titleId, displayName, "")
+    }
+
+    /**
+     * 移除玩家已拥有的称号。
+     *
+     * @param playerUuid 玩家 UUID。
+     * @param titleId 需要移除的称号 ID。
+     * @return 异步移除结果。
+     */
+    @JvmStatic
+    fun revokeTitle(
+        playerUuid: UUID,
+        titleId: String,
+    ): CompletableFuture<TitleRevokeResult> {
+        return CompletableFuture.supplyAsync {
+            TitleService.revokeTitle(playerUuid, titleId)
+        }
+    }
+
+    /**
+     * 移除在线玩家已拥有的称号。
+     *
+     * @param player 玩家。
+     * @param titleId 需要移除的称号 ID。
+     * @return 异步移除结果。
+     */
+    @JvmStatic
+    fun revokeTitle(
+        player: Player,
+        titleId: String,
+    ): CompletableFuture<TitleRevokeResult> {
+        return revokeTitle(player.uniqueId, titleId)
+    }
+
+    /**
+     * 异步读取玩家已拥有的称号。
+     *
+     * @param playerUuid 玩家 UUID。
+     * @return 按获得时间正序排列的称号列表。
+     */
+    @JvmStatic
+    fun getOwnedTitles(playerUuid: UUID): CompletableFuture<List<PlayerTitle>> {
+        return CompletableFuture.supplyAsync {
+            TitleService.getOwnedTitles(playerUuid)
+        }
+    }
+
+    /**
+     * 异步读取玩家当前佩戴的称号。
+     *
+     * @param playerUuid 玩家 UUID。
+     * @return 当前称号，未佩戴时以 null 完成。
+     */
+    @JvmStatic
+    fun getEquippedTitle(playerUuid: UUID): CompletableFuture<PlayerTitle?> {
+        return CompletableFuture.supplyAsync {
+            TitleService.getEquippedTitle(playerUuid)
+        }
+    }
+}

--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/title/TitleService.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/title/TitleService.kt
@@ -1,0 +1,314 @@
+package cn.tj.dzd.mc.dzt.title
+
+import cn.tj.dzd.mc.dzt.data.DatabaseGuard
+import cn.tj.dzd.mc.dzt.data.table.PlayerTitleRecord
+import cn.tj.dzd.mc.dzt.data.table.playerTitleRecordMapper
+import org.bukkit.Bukkit
+import org.bukkit.entity.Player
+import org.bukkit.event.player.AsyncPlayerPreLoginEvent
+import org.bukkit.event.player.PlayerJoinEvent
+import org.bukkit.event.player.PlayerQuitEvent
+import taboolib.common.LifeCycle
+import taboolib.common.platform.Awake
+import taboolib.common.platform.event.SubscribeEvent
+import java.util.Locale
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * 称号的数据库服务与聊天快照缓存。
+ *
+ * 数据库方法均为同步方法，调用方应在异步线程中执行；对外接口请使用 [TitleApi]。
+ */
+internal object TitleService {
+
+    private const val MAX_TITLE_ID_LENGTH = 64
+    private const val MAX_DISPLAY_NAME_LENGTH = 64
+    private const val MAX_DESCRIPTION_LENGTH = 256
+    private val validTitleId = Regex("[a-z0-9._-]+")
+
+    private val equippedTitleCache = ConcurrentHashMap<UUID, PlayerTitle>()
+    private val cacheLoadTokens = ConcurrentHashMap<UUID, Long>()
+    private val cacheTokenSequence = AtomicLong()
+
+    /**
+     * 授予玩家一个称号。
+     *
+     * 新称号不会自动佩戴，需由玩家在称号菜单中选择。
+     *
+     * @param uuid 玩家 UUID。
+     * @param titleId 称号稳定 ID，允许小写字母、数字、点、下划线与连字符。
+     * @param displayName 称号显示名，支持 `§` 颜色代码。
+     * @param description 称号介绍，允许为空。
+     * @return 授予结果。
+     * @throws IllegalArgumentException 参数不合法时抛出。
+     */
+    fun grantTitle(
+        uuid: UUID,
+        titleId: String,
+        displayName: String,
+        description: String,
+    ): TitleGrantResult {
+        val normalizedId = normalizeTitleId(titleId)
+        val normalizedDisplayName = normalizeDisplayName(displayName)
+        val normalizedDescription = normalizeDescription(description)
+        val recordId = recordId(uuid, normalizedId)
+
+        return DatabaseGuard.execute("授予称号", TitleGrantResult.FAILED) {
+            if (playerTitleRecordMapper.findById(recordId) != null) {
+                return@execute TitleGrantResult.ALREADY_OWNED
+            }
+
+            playerTitleRecordMapper.insert(
+                PlayerTitleRecord(
+                    recordId = recordId,
+                    uuid = uuid,
+                    titleId = normalizedId,
+                    displayName = normalizedDisplayName,
+                    description = normalizedDescription,
+                    acquiredAt = System.currentTimeMillis(),
+                    equipped = false,
+                )
+            )
+            TitleGrantResult.GRANTED
+        }
+    }
+
+    /**
+     * 移除玩家已拥有的称号。
+     *
+     * 如果该称号正在佩戴，移除后会同步刷新聊天称号缓存。
+     *
+     * @param uuid 玩家 UUID。
+     * @param titleId 需要移除的称号 ID。
+     * @return 移除结果。
+     * @throws IllegalArgumentException 称号 ID 不合法时抛出。
+     */
+    fun revokeTitle(uuid: UUID, titleId: String): TitleRevokeResult {
+        val normalizedId = normalizeTitleId(titleId)
+        val targetRecordId = recordId(uuid, normalizedId)
+        val result = DatabaseGuard.execute("移除玩家称号", TitleRevokeResult.FAILED) {
+            playerTitleRecordMapper.transaction {
+                findById(targetRecordId) ?: return@transaction TitleRevokeResult.NOT_OWNED
+                deleteById(targetRecordId)
+                TitleRevokeResult.REVOKED
+            }.getOrThrow()
+        }
+
+        if (result == TitleRevokeResult.REVOKED) {
+            updateEquippedTitleCache(uuid, getEquippedTitle(uuid))
+        }
+        return result
+    }
+
+    /**
+     * 读取玩家已拥有的所有称号。
+     *
+     * @param uuid 玩家 UUID。
+     * @return 按获得时间正序排列的称号。
+     */
+    fun getOwnedTitles(uuid: UUID): List<PlayerTitle> {
+        return DatabaseGuard.execute("读取玩家称号", emptyList()) {
+            playerTitleRecordMapper.findAll {
+                "uuid" eq uuid.toString()
+            }.sortedBy { it.acquiredAt }
+                .map { it.toPlayerTitle() }
+        }
+    }
+
+    /**
+     * 读取玩家当前佩戴的称号。
+     *
+     * @param uuid 玩家 UUID。
+     * @return 当前称号，未佩戴时返回 null。
+     */
+    fun getEquippedTitle(uuid: UUID): PlayerTitle? {
+        return DatabaseGuard.execute<PlayerTitle?>("读取已佩戴称号", null) {
+            playerTitleRecordMapper.findOne {
+                "uuid" eq uuid.toString()
+                "equipped" eq true
+            }?.toPlayerTitle()
+        }
+    }
+
+    /**
+     * 佩戴玩家已拥有的称号。
+     *
+     * 先取消该玩家的其他称号，再佩戴指定称号，两步在同一个事务中完成。
+     *
+     * @param uuid 玩家 UUID。
+     * @param titleId 需要佩戴的称号 ID。
+     * @return 佩戴结果。
+     */
+    fun equipTitle(uuid: UUID, titleId: String): TitleEquipResult {
+        val normalizedId = normalizeTitleId(titleId)
+        val result = DatabaseGuard.execute("佩戴称号", TitleEquipResult.FAILED) {
+            playerTitleRecordMapper.transaction {
+                val selected = findById(recordId(uuid, normalizedId))
+                    ?: return@transaction TitleEquipResult.NOT_OWNED
+                if (selected.equipped) {
+                    return@transaction TitleEquipResult.ALREADY_EQUIPPED
+                }
+
+                rawUpdate {
+                    set("equipped", false)
+                    where {
+                        "uuid" eq uuid.toString()
+                    }
+                }
+                selected.equipped = true
+                update(selected)
+                TitleEquipResult.EQUIPPED
+            }.getOrThrow()
+        }
+
+        when (result) {
+            TitleEquipResult.EQUIPPED,
+            TitleEquipResult.ALREADY_EQUIPPED -> updateEquippedTitleCache(uuid, getEquippedTitle(uuid))
+            else -> Unit
+        }
+        return result
+    }
+
+    /**
+     * 取消玩家当前佩戴的称号。
+     *
+     * @param uuid 玩家 UUID。
+     * @return 取消佩戴结果。
+     */
+    fun unequipTitle(uuid: UUID): TitleEquipResult {
+        val result = DatabaseGuard.execute("取消佩戴称号", TitleEquipResult.FAILED) {
+            playerTitleRecordMapper.transaction {
+                rawUpdate {
+                    set("equipped", false)
+                    where {
+                        "uuid" eq uuid.toString()
+                    }
+                }
+                TitleEquipResult.UNEQUIPPED
+            }.getOrThrow()
+        }
+
+        if (result == TitleEquipResult.UNEQUIPPED) {
+            updateEquippedTitleCache(uuid, null)
+        }
+        return result
+    }
+
+    /**
+     * 返回聊天渲染使用的非阻塞称号快照。
+     */
+    fun getCachedEquippedTitle(uuid: UUID): PlayerTitle? {
+        return equippedTitleCache[uuid]
+    }
+
+    @Awake(LifeCycle.ACTIVE)
+    fun loadOnlinePlayerCaches() {
+        Bukkit.getOnlinePlayers().forEach(::refreshEquippedTitleCache)
+    }
+
+    @Awake(LifeCycle.DISABLE)
+    fun clearCaches() {
+        equippedTitleCache.clear()
+        cacheLoadTokens.clear()
+    }
+
+    @SubscribeEvent
+    fun onPlayerPreLogin(event: AsyncPlayerPreLoginEvent) {
+        val uuid = event.uniqueId
+        updateEquippedTitleCache(uuid, getEquippedTitle(uuid), createIfAbsent = true)
+    }
+
+    @SubscribeEvent
+    fun onPlayerJoin(event: PlayerJoinEvent) {
+        refreshEquippedTitleCache(event.player)
+    }
+
+    @SubscribeEvent
+    fun onPlayerQuit(event: PlayerQuitEvent) {
+        val uuid = event.player.uniqueId
+        cacheLoadTokens.remove(uuid)
+        equippedTitleCache.remove(uuid)
+    }
+
+    private fun refreshEquippedTitleCache(player: Player) {
+        val uuid = player.uniqueId
+        val token = cacheTokenSequence.incrementAndGet()
+        cacheLoadTokens[uuid] = token
+
+        CompletableFuture.supplyAsync {
+            getEquippedTitle(uuid)
+        }.whenComplete { title, error ->
+            if (error != null || cacheLoadTokens[uuid] != token) {
+                return@whenComplete
+            }
+            if (title == null) {
+                equippedTitleCache.remove(uuid)
+            } else {
+                equippedTitleCache[uuid] = title
+            }
+        }
+    }
+
+    private fun updateEquippedTitleCache(
+        uuid: UUID,
+        title: PlayerTitle?,
+        createIfAbsent: Boolean = false,
+    ) {
+        if (!createIfAbsent && !cacheLoadTokens.containsKey(uuid)) {
+            return
+        }
+        cacheLoadTokens[uuid] = cacheTokenSequence.incrementAndGet()
+        if (title == null) {
+            equippedTitleCache.remove(uuid)
+        } else {
+            equippedTitleCache[uuid] = title
+        }
+    }
+
+    private fun normalizeTitleId(titleId: String): String {
+        val normalized = titleId.trim().lowercase(Locale.ROOT)
+        require(normalized.isNotEmpty()) { "称号 ID 不能为空" }
+        require(normalized.length <= MAX_TITLE_ID_LENGTH) {
+            "称号 ID 长度不能超过 $MAX_TITLE_ID_LENGTH 个字符"
+        }
+        require(validTitleId.matches(normalized)) {
+            "称号 ID 只能包含小写字母、数字、点、下划线与连字符"
+        }
+        return normalized
+    }
+
+    private fun normalizeDisplayName(displayName: String): String {
+        val normalized = displayName.trim()
+        require(normalized.isNotEmpty()) { "称号显示名不能为空" }
+        require(normalized.length <= MAX_DISPLAY_NAME_LENGTH) {
+            "称号显示名长度不能超过 $MAX_DISPLAY_NAME_LENGTH 个字符"
+        }
+        require('\n' !in normalized && '\r' !in normalized) { "称号显示名不能包含换行" }
+        return normalized
+    }
+
+    private fun normalizeDescription(description: String): String {
+        val normalized = description
+            .replace("\r\n", "\n")
+            .replace('\r', '\n')
+            .trim()
+        require(normalized.length <= MAX_DESCRIPTION_LENGTH) {
+            "称号介绍长度不能超过 $MAX_DESCRIPTION_LENGTH 个字符"
+        }
+        require(normalized.none { it.isISOControl() && it != '\n' && it != '\t' }) {
+            "称号介绍包含不可用的控制字符"
+        }
+        return normalized
+    }
+
+    private fun recordId(uuid: UUID, titleId: String): String {
+        return "$uuid:$titleId"
+    }
+
+    private fun PlayerTitleRecord.toPlayerTitle(): PlayerTitle {
+        return PlayerTitle(titleId, displayName, description, acquiredAt, equipped)
+    }
+}

--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/title/command/TitleAdminCommand.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/title/command/TitleAdminCommand.kt
@@ -1,0 +1,275 @@
+package cn.tj.dzd.mc.dzt.title.command
+
+import cn.tj.dzd.mc.dzt.title.PlayerTitle
+import cn.tj.dzd.mc.dzt.title.TitleApi
+import cn.tj.dzd.mc.dzt.title.TitleGrantResult
+import cn.tj.dzd.mc.dzt.title.TitleRevokeResult
+import cn.tj.dzd.mc.dzt.util.foliaRun
+import org.bukkit.entity.Player
+import taboolib.common.platform.ProxyCommandSender
+import taboolib.common.platform.command.CommandBody
+import taboolib.common.platform.command.CommandContext
+import taboolib.common.platform.command.CommandHeader
+import taboolib.common.platform.command.PermissionDefault
+import taboolib.common.platform.command.mainCommand
+import taboolib.common.platform.command.subCommand
+import taboolib.common.platform.function.onlinePlayers
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+
+/**
+ * 称号管理命令。
+ *
+ * 命令头默认仅向 OP 授权，每个执行器还会再次检查 [ProxyCommandSender.isOp]，
+ * 避免普通玩家被权限插件授予节点后绕过“仅 OP”限制。
+ */
+@CommandHeader(
+    name = "dzt",
+    aliases = ["dztadmin"],
+    description = "DZT 管理命令",
+    usage = "/dzt title",
+    permission = "dzt.title.admin",
+    // TabooLib 注册命令时会把该字段作为纯文本 Component 构造，不能使用 § 颜色码。
+    permissionMessage = "仅服务器 OP 可使用称号管理命令。",
+    permissionDefault = PermissionDefault.OP,
+    newParser = true,
+)
+object TitleAdminCommand {
+
+    private val beijingTimeFormatter: DateTimeFormatter = DateTimeFormatter
+        .ofPattern("yyyy-MM-dd HH:mm:ss")
+        .withZone(ZoneId.of("Asia/Shanghai"))
+
+    private data class CommandTarget(val uuid: UUID, val label: String)
+
+    @CommandBody
+    val main = mainCommand {
+        execute<ProxyCommandSender> { sender, _, _ ->
+            if (sender.requireOp()) {
+                sender.sendHelp()
+            }
+        }
+    }
+
+    @CommandBody(aliases = ["titles"], description = "管理玩家称号")
+    val title = subCommand {
+        execute<ProxyCommandSender> { sender, _, _ ->
+            if (sender.requireOp()) {
+                sender.sendHelp()
+            }
+        }
+
+        literal("give", "grant", description = "授予玩家称号") {
+            dynamic("player") {
+                suggestionUncheck<ProxyCommandSender> { _, _ -> onlinePlayerNames() }
+                dynamic("id") {
+                    dynamic("displayName") {
+                        execute<ProxyCommandSender> { sender, context, _ ->
+                            executeGrant(sender, context, "")
+                        }
+                        dynamic("description", optional = true) {
+                            execute<ProxyCommandSender> { sender, context, argument ->
+                                executeGrant(sender, context, argument)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        literal("remove", "revoke", "take", description = "移除玩家称号") {
+            dynamic("player") {
+                suggestionUncheck<ProxyCommandSender> { _, _ -> onlinePlayerNames() }
+                dynamic("id") {
+                    execute<ProxyCommandSender> { sender, context, _ ->
+                        executeRevoke(sender, context)
+                    }
+                }
+            }
+        }
+
+        literal("list", description = "查看玩家已拥有称号") {
+            dynamic("player") {
+                suggestionUncheck<ProxyCommandSender> { _, _ -> onlinePlayerNames() }
+                execute<ProxyCommandSender> { sender, context, _ ->
+                    executeList(sender, context)
+                }
+            }
+        }
+    }
+
+    private fun executeGrant(
+        sender: ProxyCommandSender,
+        context: CommandContext<ProxyCommandSender>,
+        description: String,
+    ) {
+        if (!sender.requireOp()) {
+            return
+        }
+        val target = sender.resolveTarget(context["player"]) ?: return
+        val titleId = context["id"]
+        val displayName = context["displayName"].translateLegacyColorCodes()
+        val normalizedDescription = description.translateLegacyColorCodes()
+
+        sender.sendLines("§e正在向 ${target.label} 授予称号……")
+        TitleApi.grantTitle(target.uuid, titleId, displayName, normalizedDescription).whenComplete { result, error ->
+            if (error != null) {
+                sender.sendLines("§c授予称号失败：${error.readableMessage()}")
+                return@whenComplete
+            }
+
+            when (result) {
+                TitleGrantResult.GRANTED -> sender.sendLines(
+                    "§a已向 ${target.label} 授予称号 §f$titleId§a。"
+                )
+                TitleGrantResult.ALREADY_OWNED -> sender.sendLines(
+                    "§e${target.label} 已拥有称号 §f$titleId§e。"
+                )
+                TitleGrantResult.FAILED,
+                null -> sender.sendLines("§c向 ${target.label} 授予称号失败。")
+            }
+        }
+    }
+
+    private fun executeRevoke(
+        sender: ProxyCommandSender,
+        context: CommandContext<ProxyCommandSender>,
+    ) {
+        if (!sender.requireOp()) {
+            return
+        }
+        val target = sender.resolveTarget(context["player"]) ?: return
+        val titleId = context["id"]
+
+        sender.sendLines("§e正在移除 ${target.label} 的称号……")
+        TitleApi.revokeTitle(target.uuid, titleId).whenComplete { result, error ->
+            if (error != null) {
+                sender.sendLines("§c移除称号失败：${error.readableMessage()}")
+                return@whenComplete
+            }
+
+            when (result) {
+                TitleRevokeResult.REVOKED -> sender.sendLines(
+                    "§a已移除 ${target.label} 的称号 §f$titleId§a。"
+                )
+                TitleRevokeResult.NOT_OWNED -> sender.sendLines(
+                    "§e${target.label} 未拥有称号 §f$titleId§e。"
+                )
+                TitleRevokeResult.FAILED,
+                null -> sender.sendLines("§c移除 ${target.label} 的称号失败。")
+            }
+        }
+    }
+
+    private fun executeList(
+        sender: ProxyCommandSender,
+        context: CommandContext<ProxyCommandSender>,
+    ) {
+        if (!sender.requireOp()) {
+            return
+        }
+        val target = sender.resolveTarget(context["player"]) ?: return
+
+        TitleApi.getOwnedTitles(target.uuid).whenComplete { titles, error ->
+            if (error != null) {
+                sender.sendLines("§c读取称号失败：${error.readableMessage()}")
+                return@whenComplete
+            }
+            if (titles.isNullOrEmpty()) {
+                sender.sendLines("§e${target.label} 尚未拥有称号。")
+                return@whenComplete
+            }
+
+            sender.sendLines(
+                buildList {
+                    add("§6${target.label} 的称号（${titles.size}）：")
+                    titles.forEach { title ->
+                        add(title.toCommandLine())
+                    }
+                }
+            )
+        }
+    }
+
+    private fun ProxyCommandSender.requireOp(): Boolean {
+        if (isOp) {
+            return true
+        }
+        sendLines("§c仅服务器 OP 可使用称号管理命令。")
+        return false
+    }
+
+    private fun ProxyCommandSender.resolveTarget(input: String): CommandTarget? {
+        val normalized = input.trim()
+        val uuid = runCatching { UUID.fromString(normalized) }.getOrNull()
+        if (uuid != null) {
+            val onlineName = onlinePlayers().firstOrNull { it.uniqueId == uuid }?.name
+            return CommandTarget(uuid, onlineName ?: uuid.toString())
+        }
+
+        val player = onlinePlayers().firstOrNull { it.name.equals(normalized, ignoreCase = true) }
+        if (player == null) {
+            sendLines("§c未找到在线玩家[$normalized]；管理离线玩家请使用 UUID。")
+            return null
+        }
+        return CommandTarget(player.uniqueId, player.name)
+    }
+
+    private fun ProxyCommandSender.sendHelp() {
+        sendLines(
+            "§6称号管理命令：",
+            "§e/dzt title give <玩家名/UUID> <ID> \"§f<显示名>§e\" [介绍]",
+            "§e/dzt title remove <玩家名/UUID> <ID>",
+            "§e/dzt title list <玩家名/UUID>",
+            "§8显示名包含空格时请使用英文引号包围，颜色代码可使用 &6 形式。",
+        )
+    }
+
+    private fun ProxyCommandSender.sendLines(vararg lines: String) {
+        sendLines(lines.asList())
+    }
+
+    private fun ProxyCommandSender.sendLines(lines: List<String>) {
+        val player = castSafely<Player>()
+        if (player != null) {
+            player.foliaRun {
+                lines.forEach { line -> sendMessage(line) }
+            }
+        } else {
+            lines.forEach(::sendMessage)
+        }
+    }
+
+    private fun PlayerTitle.toCommandLine(): String {
+        val equippedMarker = if (equipped) "§a[佩戴] " else "§7[未佩戴] "
+        val descriptionText = description
+            .replace('\n', ' ')
+            .ifBlank { "暂无介绍" }
+        val time = beijingTimeFormatter.format(Instant.ofEpochMilli(grantedAt))
+        return "$equippedMarker§f$id §7- §r$displayName §8| $descriptionText | $time 北京时间"
+    }
+
+    private fun Throwable.readableMessage(): String {
+        var current = this
+        while (current.cause != null && current.cause !== current) {
+            current = current.cause!!
+        }
+        return current.message ?: current.javaClass.simpleName
+    }
+
+    private fun onlinePlayerNames(): List<String> {
+        return onlinePlayers().map { it.name }.sortedWith(String.CASE_INSENSITIVE_ORDER)
+    }
+
+    private fun String.translateLegacyColorCodes(): String {
+        val chars = toCharArray()
+        for (index in 0 until chars.lastIndex) {
+            if (chars[index] == '&' && chars[index + 1].lowercaseChar() in "0123456789abcdefklmnorx") {
+                chars[index] = '§'
+            }
+        }
+        return chars.concatToString()
+    }
+}

--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/title/ui/TitleUI.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/title/ui/TitleUI.kt
@@ -1,0 +1,256 @@
+package cn.tj.dzd.mc.dzt.title.ui
+
+import cn.tj.dzd.mc.dzt.menu.ui.Menu.openMenu
+import cn.tj.dzd.mc.dzt.title.PlayerTitle
+import cn.tj.dzd.mc.dzt.title.TitleEquipResult
+import cn.tj.dzd.mc.dzt.title.TitleService
+import cn.tj.dzd.mc.dzt.util.foliaCloseInventory
+import cn.tj.dzd.mc.dzt.util.foliaRun
+import cn.tj.dzd.mc.dzt.util.isBePlayer
+import cn.tj.dzd.mc.dzt.util.sendDZTError
+import cn.tj.dzd.mc.dzt.util.sendDZTSuccess
+import cn.tj.dzd.mc.dzt.util.sendDZTTip
+import cn.tj.dzd.mc.dzt.util.sendForm
+import org.bukkit.entity.Player
+import org.geysermc.cumulus.form.ModalForm
+import org.geysermc.cumulus.form.SimpleForm
+import org.geysermc.cumulus.util.FormImage
+import taboolib.library.xseries.XMaterial
+import taboolib.module.ui.openMenu
+import taboolib.module.ui.type.PageableChest
+import taboolib.platform.util.buildItem
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
+
+/** Java 版和基岩版共用的称号选择界面。 */
+object TitleUI {
+
+    private const val DESCRIPTION_LINE_LENGTH = 32
+    private val beijingZone: ZoneId = ZoneId.of("Asia/Shanghai")
+    private val grantedTimeFormatter: DateTimeFormatter = DateTimeFormatter
+        .ofPattern("yyyy-MM-dd HH:mm:ss")
+        .withZone(beijingZone)
+    private val selectionsInProgress = ConcurrentHashMap.newKeySet<UUID>()
+
+    private sealed interface TitleOption {
+        data object Unequip : TitleOption
+        data class Owned(val title: PlayerTitle) : TitleOption
+    }
+
+    /**
+     * 读取玩家称号后，根据客户端类型打开 JE 箱子菜单或 BE 表单。
+     *
+     * @param player 需要打开称号菜单的玩家。
+     */
+    fun open(player: Player) {
+        val uuid = player.uniqueId
+        CompletableFuture.supplyAsync {
+            TitleService.getOwnedTitles(uuid)
+        }.whenComplete { titles, error ->
+            if (error != null) {
+                player.sendDZTError("读取称号失败：${error.message ?: error.javaClass.simpleName}")
+                return@whenComplete
+            }
+
+            player.foliaRun {
+                if (isBePlayer()) {
+                    openBedrock(this, titles)
+                } else {
+                    openJava(this, titles)
+                }
+            }
+        }
+    }
+
+    private fun openJava(player: Player, titles: List<PlayerTitle>) {
+        val options = buildList {
+            add(TitleOption.Unequip)
+            addAll(titles.map(TitleOption::Owned))
+        }
+
+        player.openMenu<PageableChest<TitleOption>>("§l§6称号") {
+            rows(6)
+            virtualize()
+
+            map(
+                "R###M####",
+                "#@@@@@@@#",
+                "#@@@@@@@#",
+                "#@@@@@@@#",
+                "#@@@@@@@#",
+                "###<#>###"
+            )
+
+            onClick(lock = true) {}
+            set('#', XMaterial.GRAY_STAINED_GLASS_PANE) { name = " " }
+            set('M', XMaterial.NAME_TAG) { name = "§l§6选择称号" }
+            set('R', buildItem(XMaterial.BARREL) {
+                name = "§l§e返回主菜单"
+            }) {
+                player.openMenu()
+            }
+
+            slotsBy('@')
+            elements { options }
+            onGenerate { _, option, _, _ ->
+                when (option) {
+                    TitleOption.Unequip -> buildItem(XMaterial.BARRIER) {
+                        name = "§c不佩戴称号"
+                        lore += "§7聊天时不显示称号"
+                        lore += "§e点击选择"
+                    }
+                    is TitleOption.Owned -> buildItem(XMaterial.NAME_TAG) {
+                        name = "§f[§r${option.title.displayName}§f]"
+                        lore += "§7ID: §f${option.title.id}"
+                        formatDescriptionLore(option.title.description).forEach { line ->
+                            lore += line
+                        }
+                        lore += "§7给予时间: §e${formatGrantedTime(option.title.grantedAt)}"
+                        lore += "§8时区: 北京时间"
+                        lore += if (option.title.equipped) "§a当前佩戴" else "§e点击佩戴"
+                    }
+                }
+            }
+            onClick { _, option ->
+                when (option) {
+                    TitleOption.Unequip -> select(player, null)
+                    is TitleOption.Owned -> select(player, option.title.id)
+                }
+            }
+
+            setPreviousPage(48) { _, hasPrevious ->
+                buildItem(if (hasPrevious) XMaterial.ARROW else XMaterial.GRAY_STAINED_GLASS_PANE) {
+                    name = if (hasPrevious) "§a上一页" else "§7已经是第一页"
+                }
+            }
+            setNextPage(50) { _, hasNext ->
+                buildItem(if (hasNext) XMaterial.ARROW else XMaterial.GRAY_STAINED_GLASS_PANE) {
+                    name = if (hasNext) "§a下一页" else "§7已经是最后一页"
+                }
+            }
+        }
+    }
+
+    private fun openBedrock(player: Player, titles: List<PlayerTitle>) {
+        val equipped = titles.firstOrNull(PlayerTitle::equipped)
+        val form = SimpleForm.builder()
+            .title("§l§6称号")
+            .content(
+                equipped?.let { "§7当前佩戴：§f[§r${it.displayName}§f]" }
+                    ?: "§7当前未佩戴称号。"
+            )
+            .button("返回主菜单", FormImage.Type.PATH, "textures/ui/box_ride.png")
+            .button("§c不佩戴称号", FormImage.Type.PATH, "textures/ui/cancel.png")
+
+        titles.forEach { title ->
+            val marker = if (title.equipped) "§a[当前] §r" else ""
+            form.button(
+                "$marker${title.displayName}\n§7${formatGrantedTime(title.grantedAt)}",
+                FormImage.Type.PATH,
+                "textures/items/name_tag.png"
+            )
+        }
+
+        form.validResultHandler { response ->
+            when (val clicked = response.clickedButtonId()) {
+                0 -> player.foliaRun { openMenu() }
+                1 -> select(player, null)
+                else -> {
+                    val title = titles.getOrNull(clicked - 2) ?: return@validResultHandler
+                    openBedrockTitleDetail(player, title)
+                }
+            }
+        }
+        player.sendForm(form)
+    }
+
+    private fun openBedrockTitleDetail(player: Player, title: PlayerTitle) {
+        val description = title.description.ifBlank { "暂无介绍" }
+        val primaryButton = if (title.equipped) "取消佩戴" else "佩戴"
+
+        player.sendForm(
+            ModalForm.builder()
+                .title("§l§6称号详情")
+                .content(
+                    "§7称号: §f[§r${title.displayName}§f]\n" +
+                        "§7介绍: §f$description\n" +
+                        "§7给予时间: §e${formatGrantedTime(title.grantedAt)} §8(北京时间)"
+                )
+                .button1(primaryButton)
+                .button2("返回")
+                .validResultHandler { response ->
+                    if (response.clickedButtonId() == 0) {
+                        select(player, if (title.equipped) null else title.id)
+                    } else {
+                        open(player)
+                    }
+                }
+                .closedOrInvalidResultHandler(Runnable {
+                    open(player)
+                })
+        )
+    }
+
+    private fun select(player: Player, titleId: String?) {
+        val uuid = player.uniqueId
+        if (!selectionsInProgress.add(uuid)) {
+            player.sendDZTTip("称号正在处理中，请稍候。")
+            return
+        }
+
+        player.foliaCloseInventory()
+        CompletableFuture.supplyAsync {
+            if (titleId == null) {
+                TitleService.unequipTitle(uuid)
+            } else {
+                TitleService.equipTitle(uuid, titleId)
+            }
+        }.whenComplete { result, error ->
+            selectionsInProgress.remove(uuid)
+            if (error != null) {
+                player.sendDZTError("更改佩戴称号失败：${error.message ?: error.javaClass.simpleName}")
+                return@whenComplete
+            }
+
+            when (result) {
+                TitleEquipResult.EQUIPPED -> player.sendDZTSuccess("已佩戴称号。")
+                TitleEquipResult.UNEQUIPPED -> player.sendDZTSuccess("已取消佩戴称号。")
+                TitleEquipResult.ALREADY_EQUIPPED -> player.sendDZTTip("已在佩戴该称号。")
+                TitleEquipResult.NOT_OWNED -> player.sendDZTError("你尚未拥有该称号。")
+                TitleEquipResult.FAILED -> player.sendDZTError("更改佩戴称号失败。")
+                null -> player.sendDZTError("更改佩戴称号失败。")
+            }
+
+            if (result != TitleEquipResult.FAILED) {
+                open(player)
+            }
+        }
+    }
+
+    private fun formatGrantedTime(timestamp: Long): String {
+        return grantedTimeFormatter.format(Instant.ofEpochMilli(timestamp))
+    }
+
+    private fun formatDescriptionLore(description: String): List<String> {
+        if (description.isBlank()) {
+            return listOf("§7介绍: §8暂无介绍")
+        }
+
+        return buildList {
+            add("§7介绍:")
+            description.lines().forEach { sourceLine ->
+                if (sourceLine.isEmpty()) {
+                    add("§f ")
+                } else {
+                    sourceLine.chunked(DESCRIPTION_LINE_LENGTH).forEach { line ->
+                        add("§f$line")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -15,3 +15,6 @@ redis:
   connect: 32
   timeout: 1000
   reconnectDelay: 1000
+
+preferred-route:
+  ip: 127.0.0.1


### PR DESCRIPTION
- 为称号增加介绍、授予时间及移除能力，扩展 TitleApi 与管理命令
- 完善 Java 箱子 UI 和基岩表单 UI，展示称号详情、描述及北京时间
- 将玩家日志持久化改为 TabooLib Persistent Container Mapper
- 将称号和优选线路记录封装为数据表映射
- 在主菜单中加入称号入口，优化聊天格式与颜色显示
- 延长优选线路冷却时间，并增加基岩版跳转延迟
- 增加 preferred-route.ip 配置项