### PR TITLE
feat: 为弟弟币业务接入玩家日志

### DIFF
--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/commission/CommissionService.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/commission/CommissionService.kt
@@ -4,6 +4,7 @@ import cn.tj.dzd.mc.dzt.data.repository.PersistentCommissionProgressRepository
 import cn.tj.dzd.mc.dzt.core.RepositoryResult
 import cn.tj.dzd.mc.dzt.economy.ServiceEconomy
 import cn.tj.dzd.mc.dzt.platform.DztAsyncExecutor
+import cn.tj.dzd.mc.dzt.log.PlayerLogService
 import taboolib.common.LifeCycle
 import taboolib.common.platform.Awake
 import taboolib.common.platform.function.severe
@@ -390,6 +391,11 @@ object CommissionService {
                             }
                         }
                     } else {
+                        PlayerLogService.recordCommissionReward(
+                            playerId = playerId,
+                            commissionId = definition.id,
+                            amount = definition.reward,
+                        )
                         when (repository.completeClaim(playerId, date, definition.id, operationId)) {
                             is RepositoryResult.Success -> {
                                 CommissionClaimResult(CommissionClaimStatus.SUCCESS, definition)

--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/economy/ServiceEconomy.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/economy/ServiceEconomy.kt
@@ -1,6 +1,7 @@
 package cn.tj.dzd.mc.dzt.economy
 
 import cn.tj.dzd.mc.dzt.platform.DztAsyncExecutor
+import cn.tj.dzd.mc.dzt.log.PlayerLogService
 import net.thenextlvl.service.economy.Account
 import net.thenextlvl.service.economy.EconomyController
 import net.thenextlvl.service.economy.currency.Currency
@@ -107,6 +108,9 @@ object ServiceEconomy {
                                 "接收玩家 UUID: $to",
                                 "金额: ${formatAmount(amount)}",
                             )
+                        }
+                        if (result.successful) {
+                            PlayerLogService.recordTransfer(from, to, amount)
                         }
                         result
                     }

--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/log/PlayerLogService.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/log/PlayerLogService.kt
@@ -17,6 +17,8 @@ import taboolib.common.platform.event.SubscribeEvent
 import java.sql.Timestamp
 import java.time.Instant
 import java.time.temporal.ChronoUnit
+import java.math.BigDecimal
+import java.util.UUID
 
 /**
  * 玩家行为日志服务。
@@ -94,6 +96,54 @@ object PlayerLogService {
         record(event.player, "离开服务器", "玩家离开服务器")
     }
 
+    /**
+     * 记录一次完整成功的 DDB 玩家转账。
+     *
+     * 调用方只能在转出扣款和接收入账都成功后调用；失败后已退款的操作不应写入成功日志。
+     *
+     * @param senderId 转出玩家 UUID。
+     * @param receiverId 接收玩家 UUID。
+     * @param amount 实际转账金额。
+     */
+    fun recordTransfer(senderId: UUID, receiverId: UUID, amount: BigDecimal) {
+        record(
+            playerId = senderId,
+            type = "弟弟币转账",
+            detail = "金额：${formatAmount(amount)} DDB，接收玩家 UUID：$receiverId",
+        )
+    }
+
+    /**
+     * 记录一次完成扣款和发货的 DDB 商店购买。
+     *
+     * @param playerId 购买玩家 UUID。
+     * @param productId 商品稳定 ID。
+     * @param quantity 实际购买数量。
+     * @param totalPrice 实际支付总额。
+     */
+    fun recordPurchase(playerId: UUID, productId: String, quantity: Int, totalPrice: BigDecimal) {
+        record(
+            playerId = playerId,
+            type = "弟弟币购物",
+            detail = "金额：${formatAmount(totalPrice)} DDB，数量：$quantity，商品 ID：$productId",
+        )
+    }
+
+    /**
+     * 记录一次已经成功入账的每日委托 DDB 奖励。
+     *
+     * @param playerId 获得奖励的玩家 UUID。
+     * @param commissionId 委托稳定 ID。
+     * @param amount 实际入账奖励金额。
+     */
+    fun recordCommissionReward(playerId: UUID, commissionId: String, amount: BigDecimal) {
+        record(
+            playerId = playerId,
+            type = "委托奖励",
+            detail = "金额：${formatAmount(amount)} DDB，委托 ID：$commissionId",
+        )
+    }
+
     private fun record(player: Player, type: String, detail: String) {
         val ping = runCatching { player.networkPing() }
             .getOrDefault(0)
@@ -105,10 +155,26 @@ object PlayerLogService {
         }
     }
 
+    private fun record(playerId: UUID, type: String, detail: String) {
+        val normalizedDetail = normalizeDetail(detail)
+        val message = "玩家 UUID：$playerId；$normalizedDetail".take(MAX_MESSAGE_LENGTH)
+        enqueue {
+            repository.append(type, message)
+        }
+    }
+
     private fun buildMessage(player: Player, ping: Int, detail: String): String {
-        val normalizedDetail = detail.replace('\n', ' ').replace('\r', ' ')
+        val normalizedDetail = normalizeDetail(detail)
         return "玩家名称：${player.name}，UUID：${player.uniqueId}，Ping：${ping}ms；$normalizedDetail"
             .take(MAX_MESSAGE_LENGTH)
+    }
+
+    private fun normalizeDetail(detail: String): String {
+        return detail.replace('\n', ' ').replace('\r', ' ')
+    }
+
+    private fun formatAmount(amount: BigDecimal): String {
+        return amount.stripTrailingZeros().toPlainString()
     }
 
     private fun enqueue(block: () -> Unit) {

--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/shop/ShopService.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/shop/ShopService.kt
@@ -4,6 +4,7 @@ import cn.tj.dzd.mc.dzt.data.repository.PersistentShopPurchaseRepository
 import cn.tj.dzd.mc.dzt.economy.EconomyRefundStatus
 import cn.tj.dzd.mc.dzt.economy.EconomyWithdrawalStatus
 import cn.tj.dzd.mc.dzt.economy.ServiceEconomy
+import cn.tj.dzd.mc.dzt.log.PlayerLogService
 import java.math.BigDecimal
 import java.util.UUID
 import java.util.concurrent.CompletableFuture
@@ -69,7 +70,17 @@ object ShopService {
         quantity: Int,
         inventory: ShopInventoryPort,
     ): CompletableFuture<ShopCheckoutResult> {
-        return application.purchase(playerId, productId, quantity, inventory)
+        return application.purchase(playerId, productId, quantity, inventory).thenApply { result ->
+            if (result.successful) {
+                PlayerLogService.recordPurchase(
+                    playerId = playerId,
+                    productId = requireNotNull(result.product).id,
+                    quantity = result.quantity,
+                    totalPrice = requireNotNull(result.totalPrice),
+                )
+            }
+            result
+        }
     }
 }
 


### PR DESCRIPTION
- 记录玩家成功转账的金额及收款方 UUID
- 记录商店购买成功后的商品、数量及支付金额
- 记录完成委托后成功入账的弟弟币奖励
- 仅在业务成功节点写入日志，避免记录失败或已补偿操作
- 统一通过玩家日志异步队列执行数据库写入