### PR TITLE
feat: 新增管理员菜单与快捷菜单命令

### DIFF
--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/admin/ui/AdminUI.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/admin/ui/AdminUI.kt
@@ -1,0 +1,222 @@
+package cn.tj.dzd.mc.dzt.admin.ui
+
+import cn.tj.dzd.mc.dzt.ui.MainMenuNavigation
+import cn.tj.dzd.mc.dzt.ui.OnlinePlayerSelection
+import cn.tj.dzd.mc.dzt.ui.OnlinePlayerSelectUI
+import cn.tj.dzd.mc.dzt.util.foliaCloseInventory
+import cn.tj.dzd.mc.dzt.util.foliaRun
+import cn.tj.dzd.mc.dzt.util.foliaTeleport
+import cn.tj.dzd.mc.dzt.util.isBePlayer
+import cn.tj.dzd.mc.dzt.util.runForOnlinePlayer
+import cn.tj.dzd.mc.dzt.util.sendDZTError
+import cn.tj.dzd.mc.dzt.util.sendDZTSuccess
+import cn.tj.dzd.mc.dzt.util.sendForm
+import org.bukkit.GameMode
+import org.bukkit.entity.Player
+import org.geysermc.cumulus.form.SimpleForm
+import org.geysermc.cumulus.util.FormImage
+import taboolib.library.xseries.XMaterial
+import taboolib.module.ui.openMenu
+import taboolib.module.ui.type.Chest
+import taboolib.platform.util.buildItem
+
+/** Java 箱子菜单与基岩表单共用的管理界面。 */
+object AdminUI {
+
+    /** 查看和使用管理菜单所需的权限。 */
+    const val PERMISSION = "dzt.admin"
+
+    private const val TITLE = "§l§c管理菜单"
+    private const val BACK_ICON = "textures/ui/box_ride.png"
+    private const val SPECTATOR_ICON = "textures/items/ender_eye.png"
+    private const val SURVIVAL_ICON = "textures/items/iron_sword.png"
+    private const val TELEPORT_ICON = "textures/items/ender_pearl.png"
+
+    /**
+     * 判断玩家是否可以查看和使用管理菜单。
+     *
+     * @param player 要检查的玩家。
+     * @return 玩家拥有 [PERMISSION] 时返回 `true`。
+     */
+    fun canUse(player: Player): Boolean {
+        return player.hasPermission(PERMISSION)
+    }
+
+    /**
+     * 为玩家打开管理菜单。
+     *
+     * 会在玩家实体线程重新校验权限，并根据客户端类型选择 Java 箱子菜单或基岩表单。
+     *
+     * @param player 要展示界面的在线玩家。
+     */
+    fun open(player: Player) {
+        player.foliaRun {
+            if (!requirePermission(this)) {
+                return@foliaRun
+            }
+
+            if (isBePlayer()) {
+                openBedrock(this)
+            } else {
+                openJava(this)
+            }
+        }
+    }
+
+    private fun openJava(player: Player) {
+        val target = targetGameMode(player.gameMode)
+        player.openMenu<Chest>(TITLE) {
+            rows(3)
+            virtualize()
+
+            map(
+                "R###M####",
+                "#  G T  #",
+                "#########",
+            )
+
+            onClick(lock = true) {}
+            set('#', buildItem(XMaterial.GRAY_STAINED_GLASS_PANE) { name = " " })
+            set('R', buildItem(XMaterial.BARREL) {
+                name = "§l§e返回主菜单"
+            }) {
+                MainMenuNavigation.open(player)
+            }
+            set('M', buildItem(XMaterial.COMMAND_BLOCK) {
+                name = TITLE
+            })
+            set('G', buildItem(target.javaIcon) {
+                name = "§l§6切换为${target.displayName}模式"
+                lore += "§7当前模式：§f${gameModeName(player.gameMode)}"
+                lore += "§a点击切换"
+            }) {
+                toggleGameMode(player)
+            }
+            set('T', buildItem(XMaterial.ENDER_PEARL) {
+                name = "§l§6传送至玩家"
+                lore += "§7选择一名在线玩家并立即传送"
+            }) {
+                openTeleportTargetSelection(player)
+            }
+        }
+    }
+
+    private fun openBedrock(player: Player) {
+        val current = player.gameMode
+        val target = targetGameMode(current)
+        player.sendForm(
+            SimpleForm.builder()
+                .title(TITLE)
+                .content("当前模式：${gameModeName(current)}")
+                .button("返回主菜单", FormImage.Type.PATH, BACK_ICON)
+                .button("切换为${target.displayName}模式", FormImage.Type.PATH, target.bedrockIcon)
+                .button("传送至玩家", FormImage.Type.PATH, TELEPORT_ICON)
+                .validResultHandler { response ->
+                    player.foliaRun {
+                        when (response.clickedButtonId()) {
+                            0 -> MainMenuNavigation.open(this)
+                            1 -> toggleGameMode(this)
+                            2 -> openTeleportTargetSelection(this)
+                        }
+                    }
+                }
+        )
+    }
+
+    private fun openTeleportTargetSelection(player: Player) {
+        player.foliaRun {
+            if (!requirePermission(this)) {
+                return@foliaRun
+            }
+
+            OnlinePlayerSelectUI.open(
+                player = this,
+                title = "§l§c传送至玩家",
+                description = "选择一名在线玩家并立即传送。",
+                emptyMessage = "当前没有其他在线玩家。",
+                selectLore = "§7点击立即传送至该玩家",
+                backLabel = "§l§e返回管理菜单",
+                onBack = {
+                    open(this)
+                },
+                onSelect = { target ->
+                    teleportToTarget(this, target)
+                },
+            )
+        }
+    }
+
+    private fun teleportToTarget(player: Player, target: OnlinePlayerSelection) {
+        val playerId = player.uniqueId
+        target.withOnlinePlayer {
+            val targetPlayer = this
+            player.foliaRun {
+                if (!requirePermission(this)) {
+                    return@foliaRun
+                }
+
+                foliaTeleport(targetPlayer).whenComplete { success, error ->
+                    runForOnlinePlayer(playerId) {
+                        if (error == null && success == true) {
+                            sendDZTSuccess("已传送至 ${target.name}。")
+                        } else {
+                            sendDZTError("传送失败，目标玩家可能已离线。")
+                        }
+                    }
+                }
+            }
+        }.whenComplete { available, error ->
+            if (error != null || available != true) {
+                runForOnlinePlayer(playerId) {
+                    sendDZTError("传送失败，目标玩家可能已离线。")
+                }
+            }
+        }
+    }
+
+    private fun toggleGameMode(player: Player) {
+        player.foliaRun {
+            if (!requirePermission(this)) {
+                return@foliaRun
+            }
+
+            val target = targetGameMode(gameMode)
+            // TabooLib 未提供设置玩家 GameMode 的等价接口；此处已在玩家实体线程执行。
+            gameMode = target.bukkitMode
+            sendDZTSuccess("已切换为${target.displayName}模式。")
+        }
+    }
+
+    private fun requirePermission(player: Player): Boolean {
+        if (canUse(player)) {
+            return true
+        }
+
+        player.foliaCloseInventory()
+        player.sendDZTError("你没有权限使用管理菜单。")
+        return false
+    }
+
+    private fun targetGameMode(current: GameMode): GameModeTarget {
+        return if (current == GameMode.SPECTATOR) GameModeTarget.SURVIVAL else GameModeTarget.SPECTATOR
+    }
+
+    private fun gameModeName(gameMode: GameMode): String {
+        return when (gameMode) {
+            GameMode.SURVIVAL -> "生存"
+            GameMode.CREATIVE -> "创造"
+            GameMode.ADVENTURE -> "冒险"
+            GameMode.SPECTATOR -> "旁观"
+        }
+    }
+
+    private enum class GameModeTarget(
+        val bukkitMode: GameMode,
+        val displayName: String,
+        val javaIcon: XMaterial,
+        val bedrockIcon: String,
+    ) {
+        SPECTATOR(GameMode.SPECTATOR, "旁观", XMaterial.ENDER_EYE, SPECTATOR_ICON),
+        SURVIVAL(GameMode.SURVIVAL, "生存", XMaterial.IRON_SWORD, SURVIVAL_ICON),
+    }
+}

--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/menu/command/MenuCommand.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/menu/command/MenuCommand.kt
@@ -1,0 +1,38 @@
+package cn.tj.dzd.mc.dzt.menu.command
+
+import cn.tj.dzd.mc.dzt.menu.ui.Menu
+import org.bukkit.entity.Player
+import taboolib.common.platform.ProxyCommandSender
+import taboolib.common.platform.command.CommandBody
+import taboolib.common.platform.command.CommandHeader
+import taboolib.common.platform.command.mainCommand
+
+/** 用于打开 DZT 主菜单的玩家命令。 */
+@CommandHeader(
+    name = "cd",
+    description = "打开 DZT 主菜单",
+    usage = "/cd",
+    newParser = true,
+)
+object MenuCommand {
+
+    /**
+     * 处理 `/cd` 命令并为执行玩家打开主菜单。
+     *
+     * 非玩家发送者无法使用界面，因此只会收到错误提示。
+     */
+    @CommandBody
+    val main = mainCommand {
+        execute<ProxyCommandSender> { sender, _, _ ->
+            val player = sender.castSafely<Player>()
+            if (player == null) {
+                sender.sendMessage("§c该命令只能由玩家执行。")
+                return@execute
+            }
+
+            with(Menu) {
+                player.openMenu()
+            }
+        }
+    }
+}

--- a/src/main/kotlin/cn/tj/dzd/mc/dzt/menu/ui/Menu.kt
+++ b/src/main/kotlin/cn/tj/dzd/mc/dzt/menu/ui/Menu.kt
@@ -1,5 +1,6 @@
 package cn.tj.dzd.mc.dzt.menu.ui
 
+import cn.tj.dzd.mc.dzt.admin.ui.AdminUI
 import cn.tj.dzd.mc.dzt.teleport.ui.Teleport.openTeleport
 import cn.tj.dzd.mc.dzt.commission.ui.CommissionUI
 import cn.tj.dzd.mc.dzt.economy.ui.TransferUI
@@ -90,7 +91,7 @@ object Menu {
                 "#       #",
                 "# T E C #",
                 "# H Q S #",
-                "#       #",
+                "#   A   #",
                 "#########"
             )
             set('#', buildItem(XMaterial.GRAY_STAINED_GLASS_PANE) {
@@ -137,6 +138,15 @@ object Menu {
                 CommissionUI.open(pl)
             }
 
+            if (AdminUI.canUse(pl)) {
+                set('A', buildItem(XMaterial.COMMAND_BLOCK) {
+                    name = "§l§c管理"
+                    lore += "§7打开管理菜单"
+                }) {
+                    AdminUI.open(pl)
+                }
+            }
+
             set('S', buildItem(XMaterial.WITHER_SKELETON_SKULL) {
                 name = "§l§c自杀"
                 lore += "§7结束当前生命"
@@ -162,20 +172,24 @@ object Menu {
             .button("每日委托", FormImage.Type.PATH, "textures/items/book_normal.png")
             .button("成就", FormImage.Type.PATH, "textures/ui/achievements_pause_menu_icon.png")
             .button("自杀", FormImage.Type.PATH, "textures/ui/warning_sad_steve.png")
-            .validResultHandler { res ->
-                val id = res.clickedButtonId()
-                pl.foliaRun {
-                    when (id) {
-                        0 -> openTeleport()
-                        1 -> TransferUI.openTransferUI(this)
-                        2 -> TitleUI.open(this)
-                        3 -> ShopUI.open(this)
-                        4 -> CommissionUI.open(this)
-                        5 -> foliaPerformCommand("geyser advancements")
-                        6 -> openBedrockSuicideConfirmation(this)
-                    }
+        if (AdminUI.canUse(pl)) {
+            fm.button("管理", FormImage.Type.PATH, "textures/ui/settings_glyph_color_2x.png")
+        }
+        fm.validResultHandler { res ->
+            val id = res.clickedButtonId()
+            pl.foliaRun {
+                when (id) {
+                    0 -> openTeleport()
+                    1 -> TransferUI.openTransferUI(this)
+                    2 -> TitleUI.open(this)
+                    3 -> ShopUI.open(this)
+                    4 -> CommissionUI.open(this)
+                    5 -> foliaPerformCommand("geyser advancements")
+                    6 -> openBedrockSuicideConfirmation(this)
+                    7 -> AdminUI.open(this)
                 }
             }
+        }
         pl.sendForm(fm)
     }
 


### PR DESCRIPTION
- 新增仅限 dzt.admin 权限使用的管理菜单
- 支持在旁观模式与生存模式之间切换
- 支持选择在线玩家并直接传送
- 为 Java 与基岩玩家分别提供箱子 UI 和表单 UI
- 新增 /cd 命令用于快速打开主菜单
- 补充权限复查、Folia 调度与目标离线处理